### PR TITLE
Vc listeners new wip

### DIFF
--- a/kroxylicious-app/example-proxy-config.yaml
+++ b/kroxylicious-app/example-proxy-config.yaml
@@ -12,10 +12,12 @@ virtualClusters:
   demo:
     targetCluster:
       bootstrapServers: localhost:9092
-    clusterNetworkAddressConfigProvider:
-      type: PortPerBrokerClusterNetworkAddressConfigProvider
-      config:
-        bootstrapAddress: localhost:9192
+    listeners:
+      abc:
+        clusterNetworkAddressConfigProvider:
+          type: PortPerBrokerClusterNetworkAddressConfigProvider
+          config:
+            bootstrapAddress: localhost:9192
     logNetwork: false
     logFrames: false
 filterDefinitions:

--- a/kroxylicious-integration-test-support/pom.xml
+++ b/kroxylicious-integration-test-support/pom.xml
@@ -137,6 +137,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j2-impl</artifactId>
             <scope>test</scope>

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/DefaultKroxyliciousTester.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/DefaultKroxyliciousTester.java
@@ -206,7 +206,12 @@ public class DefaultKroxyliciousTester implements KroxyliciousTester {
 
     @Override
     public Producer<String, String> producer(String virtualCluster) {
-        return clients(virtualCluster, DEFAULT_LISTENER_NAME).producer();
+        return producer(virtualCluster, DEFAULT_LISTENER_NAME);
+    }
+
+    @Override
+    public Producer<String, String> producer(String virtualCluster, String listener) {
+        return clients(virtualCluster, listener).producer();
     }
 
     @Override
@@ -221,7 +226,12 @@ public class DefaultKroxyliciousTester implements KroxyliciousTester {
 
     @Override
     public Consumer<String, String> consumer(String virtualCluster) {
-        return clients(virtualCluster, DEFAULT_LISTENER_NAME).consumer();
+        return consumer(virtualCluster, DEFAULT_LISTENER_NAME);
+    }
+
+    @Override
+    public Consumer<String, String> consumer(String virtualCluster, String listener) {
+        return clients(virtualCluster, listener).consumer();
     }
 
     @Override

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/DefaultKroxyliciousTester.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/DefaultKroxyliciousTester.java
@@ -116,7 +116,11 @@ public class DefaultKroxyliciousTester implements KroxyliciousTester {
     private void configureClientTls(String virtualCluster, Map<String, Object> defaultClientConfig) {
         final VirtualCluster definedCluster = kroxyliciousConfig.virtualClusters().get(virtualCluster);
         if (definedCluster != null) {
-            final Optional<Tls> tls = definedCluster.tls();
+            if (definedCluster.listeners().size() > 1) {
+                throw new IllegalArgumentException("TODO: support multiple listeners");
+            }
+            // TODO support specifying listener in the test APIs
+            final Optional<Tls> tls = definedCluster.listeners().values().stream().findFirst().orElseThrow().tls();
             if (tls.isPresent()) {
                 defaultClientConfig.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SSL.name);
                 if (trustStoreConfiguration.isPresent()) {

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/KroxyliciousTester.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/KroxyliciousTester.java
@@ -55,12 +55,22 @@ public interface KroxyliciousTester extends Closeable {
 
     /**
      * Creates an Admin Client configured with the kroxylicious bootstrap server
-     * for a specific virtual cluster.
+     * for a specific virtual cluster with a single listener.
      * @param virtualCluster the virtual cluster we want the client to connect to
      * @return Admin client
      * @throws IllegalArgumentException if the named virtual cluster is not part of the kroxylicious server
      */
     Admin admin(String virtualCluster);
+
+    /**
+     * Creates an Admin Client configured with the kroxylicious bootstrap server
+     * for a specific listener on a specific virtual cluster
+     * @param virtualCluster the virtual cluster we want the client to connect to
+     * @param listener the listener we want the client to connect to
+     * @return Admin client
+     * @throws IllegalArgumentException if the named virtual cluster is not part of the kroxylicious server, or if the virtual cluster does not have a listener with this name
+     */
+    Admin admin(String virtualCluster, String listener);
 
     /**
      * Creates a Producer configured with the kroxylicious bootstrap server
@@ -262,7 +272,7 @@ public interface KroxyliciousTester extends Closeable {
     /**
      * @return the bootstrap address of the named virtual cluster
      */
-    String getBootstrapAddress(String clusterName);
+    String getBootstrapAddress(String clusterName, String listener);
 
     /**
      * @return the Admin Http Client

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/KroxyliciousTester.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/KroxyliciousTester.java
@@ -101,12 +101,22 @@ public interface KroxyliciousTester extends Closeable {
 
     /**
      * Creates a Producer configured with the kroxylicious bootstrap server
-     * for a specific virtual cluster.
+     * for a specific virtual cluster for the default listener.
      * @param virtualCluster the virtual cluster we want the client to connect to
      * @return Producer
      * @throws IllegalArgumentException if the named virtual cluster is not part of the kroxylicious server
      */
     Producer<String, String> producer(String virtualCluster);
+
+    /**
+     * Creates a Producer configured with the kroxylicious bootstrap server
+     * for a specific virtual cluster for the default listener.
+     * @param virtualCluster the virtual cluster we want the client to connect to
+     * @param listener the listener we want the client to connect to
+     * @return Producer
+     * @throws IllegalArgumentException if the named virtual cluster is not part of the kroxylicious server or if the virtual cluster doesn't have the named listener
+     */
+    Producer<String, String> producer(String virtualCluster, String listener);
 
     /**
      * Creates a Producer configured with the kroxylicious bootstrap server
@@ -172,6 +182,17 @@ public interface KroxyliciousTester extends Closeable {
      * @throws IllegalArgumentException if the named virtual cluster is not part of the kroxylicious server
      */
     Consumer<String, String> consumer(String virtualCluster);
+
+    /**
+     * Creates a Consumer configured with the kroxylicious bootstrap server
+     * for a specific virtual cluster and listener. Also sets a random group id
+     * and sets auto offset reset to "earliest".
+     * @param virtualCluster the virtual cluster we want the client to connect to
+     * @param listener the listener to connect to
+     * @return Consumer
+     * @throws IllegalArgumentException if the named virtual cluster is not part of the kroxylicious server or if the virtual cluster doesn't have the named listener
+     */
+    Consumer<String, String> consumer(String virtualCluster, String listener);
 
     /**
      * Creates a Consumer configured with the kroxylicious bootstrap server

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/ListenerId.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/ListenerId.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.test.tester;
+
+public record ListenerId(String virtualCluster, String listener) {}

--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/proxy/config/ConfigurationTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/proxy/config/ConfigurationTest.java
@@ -28,6 +28,7 @@ import io.kroxylicious.proxy.config.tls.TlsClientAuth;
 import io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.PortPerBrokerClusterNetworkAddressConfigProvider;
 import io.kroxylicious.proxy.service.HostPort;
 
+import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.DEFAULT_LISTENER_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.params.provider.Arguments.argumentSet;
@@ -272,9 +273,12 @@ class ConfigurationTest {
                                 .addToVirtualClusters("demo", new VirtualClusterBuilder()
                                         .withNewTargetCluster()
                                         .withBootstrapServers("kafka.example:1234")
-                                        .endTargetCluster().addToListeners("default", new VirtualClusterListenerBuilder().withClusterNetworkAddressConfigProvider(
-                                                new ClusterNetworkAddressConfigProviderDefinitionBuilder("SniRoutingClusterNetworkAddressConfigProvider").withConfig(
-                                                        "bootstrapAddress", "cluster1:9192", "brokerAddressPattern", "broker-$(nodeId)").build())
+                                        .endTargetCluster().addToListeners(DEFAULT_LISTENER_NAME, new VirtualClusterListenerBuilder()
+                                                .withClusterNetworkAddressConfigProvider(
+                                                        new ClusterNetworkAddressConfigProviderDefinitionBuilder("SniRoutingClusterNetworkAddressConfigProvider")
+                                                                .withConfig(
+                                                                        "bootstrapAddress", "cluster1:9192", "brokerAddressPattern", "broker-$(nodeId)")
+                                                                .build())
                                                 .build())
                                         .build())
                                 .build(),
@@ -296,9 +300,12 @@ class ConfigurationTest {
                                 .addToVirtualClusters("demo", new VirtualClusterBuilder()
                                         .withNewTargetCluster()
                                         .withBootstrapServers("kafka.example:1234")
-                                        .endTargetCluster().addToListeners("default", new VirtualClusterListenerBuilder().withClusterNetworkAddressConfigProvider(
-                                                new ClusterNetworkAddressConfigProviderDefinitionBuilder("SniRoutingClusterNetworkAddressConfigProvider").withConfig(
-                                                        "bootstrapAddress", "cluster1:9192", "advertisedBrokerAddressPattern", "broker-$(nodeId)").build())
+                                        .endTargetCluster().addToListeners(DEFAULT_LISTENER_NAME, new VirtualClusterListenerBuilder()
+                                                .withClusterNetworkAddressConfigProvider(
+                                                        new ClusterNetworkAddressConfigProviderDefinitionBuilder("SniRoutingClusterNetworkAddressConfigProvider")
+                                                                .withConfig(
+                                                                        "bootstrapAddress", "cluster1:9192", "advertisedBrokerAddressPattern", "broker-$(nodeId)")
+                                                                .build())
                                                 .build())
                                         .build())
                                 .build(),
@@ -358,7 +365,7 @@ class ConfigurationTest {
                                         .withNewTargetCluster()
                                         .withBootstrapServers("kafka.example:1234")
                                         .endTargetCluster()
-                                        .addToListeners("default", new VirtualClusterListenerBuilder().withClusterNetworkAddressConfigProvider(
+                                        .addToListeners(DEFAULT_LISTENER_NAME, new VirtualClusterListenerBuilder().withClusterNetworkAddressConfigProvider(
                                                 new ClusterNetworkAddressConfigProviderDefinitionBuilder("SniRoutingClusterNetworkAddressConfigProvider").withConfig(
                                                         "bootstrapAddress", "cluster1:9192", "advertisedBrokerAddressPattern", "broker-$(nodeId)").build())
                                                 .withNewTls()
@@ -396,7 +403,7 @@ class ConfigurationTest {
                                         .withNewTargetCluster()
                                         .withBootstrapServers("kafka.example:1234")
                                         .endTargetCluster()
-                                        .addToListeners("default", new VirtualClusterListenerBuilder().withClusterNetworkAddressConfigProvider(
+                                        .addToListeners(DEFAULT_LISTENER_NAME, new VirtualClusterListenerBuilder().withClusterNetworkAddressConfigProvider(
                                                 new ClusterNetworkAddressConfigProviderDefinitionBuilder("SniRoutingClusterNetworkAddressConfigProvider").withConfig(
                                                         "bootstrapAddress", "cluster1:9192", "advertisedBrokerAddressPattern", "broker-$(nodeId)").build())
                                                 .withNewTls()
@@ -445,7 +452,7 @@ class ConfigurationTest {
                                         .withNewTls()
                                         .endTls()
                                         .endTargetCluster()
-                                        .addToListeners("default", new VirtualClusterListenerBuilder()
+                                        .addToListeners(DEFAULT_LISTENER_NAME, new VirtualClusterListenerBuilder()
                                                 .withClusterNetworkAddressConfigProvider(
                                                         new ClusterNetworkAddressConfigProviderDefinitionBuilder(
                                                                 "SniRoutingClusterNetworkAddressConfigProvider")
@@ -481,7 +488,7 @@ class ConfigurationTest {
                                         .endTrustStoreTrust()
                                         .endTls()
                                         .endTargetCluster()
-                                        .addToListeners("default", new VirtualClusterListenerBuilder()
+                                        .addToListeners(DEFAULT_LISTENER_NAME, new VirtualClusterListenerBuilder()
                                                 .withClusterNetworkAddressConfigProvider(
                                                         new ClusterNetworkAddressConfigProviderDefinitionBuilder(
                                                                 "SniRoutingClusterNetworkAddressConfigProvider")
@@ -522,7 +529,7 @@ class ConfigurationTest {
                                         .endTrustStoreTrust()
                                         .endTls()
                                         .endTargetCluster()
-                                        .addToListeners("default", new VirtualClusterListenerBuilder()
+                                        .addToListeners(DEFAULT_LISTENER_NAME, new VirtualClusterListenerBuilder()
                                                 .withClusterNetworkAddressConfigProvider(
                                                         new ClusterNetworkAddressConfigProviderDefinitionBuilder(
                                                                 "SniRoutingClusterNetworkAddressConfigProvider")
@@ -559,7 +566,7 @@ class ConfigurationTest {
                                         .withNewInsecureTlsTrust(true)
                                         .endTls()
                                         .endTargetCluster()
-                                        .addToListeners("default", new VirtualClusterListenerBuilder()
+                                        .addToListeners(DEFAULT_LISTENER_NAME, new VirtualClusterListenerBuilder()
                                                 .withClusterNetworkAddressConfigProvider(
                                                         new ClusterNetworkAddressConfigProviderDefinitionBuilder(
                                                                 "SniRoutingClusterNetworkAddressConfigProvider")

--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/test/tester/DefaultKroxyliciousTesterTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/test/tester/DefaultKroxyliciousTesterTest.java
@@ -40,6 +40,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import io.kroxylicious.proxy.config.ClusterNetworkAddressConfigProviderDefinitionBuilder;
 import io.kroxylicious.proxy.config.ConfigurationBuilder;
 import io.kroxylicious.proxy.config.VirtualClusterBuilder;
+import io.kroxylicious.proxy.config.VirtualClusterListenerBuilder;
 import io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.PortPerBrokerClusterNetworkAddressConfigProvider;
 import io.kroxylicious.testing.kafka.common.KeytoolCertificateGenerator;
 
@@ -550,15 +551,17 @@ class DefaultKroxyliciousTesterTest {
                 .withNewTargetCluster()
                 .withBootstrapServers(backingCluster)
                 .endTargetCluster()
-                .withNewTls()
-                .withNewKeyStoreKey()
-                .withStoreFile(keytoolCertificateGenerator.getKeyStoreLocation())
-                .withNewInlinePasswordStoreProvider(keytoolCertificateGenerator.getPassword())
-                .endKeyStoreKey()
-                .endTls()
-                .withClusterNetworkAddressConfigProvider(
-                        new ClusterNetworkAddressConfigProviderDefinitionBuilder(PortPerBrokerClusterNetworkAddressConfigProvider.class.getName())
-                                .withConfig("bootstrapAddress", DEFAULT_PROXY_BOOTSTRAP).build());
+                .addToListeners("default", new VirtualClusterListenerBuilder()
+                        .withNewTls()
+                        .withNewKeyStoreKey()
+                        .withStoreFile(keytoolCertificateGenerator.getKeyStoreLocation())
+                        .withNewInlinePasswordStoreProvider(keytoolCertificateGenerator.getPassword())
+                        .endKeyStoreKey()
+                        .endTls()
+                        .withClusterNetworkAddressConfigProvider(
+                                new ClusterNetworkAddressConfigProviderDefinitionBuilder(PortPerBrokerClusterNetworkAddressConfigProvider.class.getName())
+                                        .withConfig("bootstrapAddress", DEFAULT_PROXY_BOOTSTRAP).build())
+                        .build());
         configurationBuilder
                 .addToVirtualClusters(TLS_CLUSTER, vcb.build());
 

--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/test/tester/DefaultKroxyliciousTesterTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/test/tester/DefaultKroxyliciousTesterTest.java
@@ -196,6 +196,22 @@ class DefaultKroxyliciousTesterTest {
 
     @SuppressWarnings("resource")
     @Test
+    void shouldCreateProducerForVirtualClusterCustomListener() {
+        // Given
+        try (var tester = buildMultiListenerTester()) {
+
+            // When
+            tester.producer(DEFAULT_CLUSTER, CUSTOM_LISTENER_NAME);
+
+            // Then
+            // In theory the bootstrap address is predicable but asserting it is not part of this test
+            verify(clientFactory).build(eq(new ListenerId(DEFAULT_CLUSTER, CUSTOM_LISTENER_NAME)), anyMap());
+            verify(kroxyliciousClients).producer();
+        }
+    }
+
+    @SuppressWarnings("resource")
+    @Test
     void shouldCreateProducerForDefaultVirtualCluster() {
         // Given
         try (var tester = buildDefaultTester()) {
@@ -222,6 +238,22 @@ class DefaultKroxyliciousTesterTest {
             // Then
             // In theory the bootstrap address is predicable but asserting it is not part of this test
             verify(clientFactory).build(eq(new ListenerId(DEFAULT_CLUSTER, DEFAULT_LISTENER_NAME)), anyMap());
+            verify(kroxyliciousClients).consumer();
+        }
+    }
+
+    @SuppressWarnings("resource")
+    @Test
+    void shouldCreateConsumerForVirtualClusterAndCustomListener() {
+        // Given
+        try (var tester = buildMultiListenerTester()) {
+
+            // When
+            tester.consumer(DEFAULT_CLUSTER, CUSTOM_LISTENER_NAME);
+
+            // Then
+            // In theory the bootstrap address is predicable but asserting it is not part of this test
+            verify(clientFactory).build(eq(new ListenerId(DEFAULT_CLUSTER, CUSTOM_LISTENER_NAME)), anyMap());
             verify(kroxyliciousClients).consumer();
         }
     }

--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/test/tester/KroxyliciousTestersTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/test/tester/KroxyliciousTestersTest.java
@@ -50,6 +50,7 @@ import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.DEFAULT_LISTENER_NAME;
 import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.DEFAULT_VIRTUAL_CLUSTER;
 import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.proxy;
 import static io.kroxylicious.test.tester.KroxyliciousTesters.kroxyliciousTester;
@@ -320,7 +321,7 @@ class KroxyliciousTestersTest {
                 .withNewTargetCluster()
                 .withBootstrapServers(clusterBootstrapServers)
                 .endTargetCluster()
-                .addToListeners("default", new VirtualClusterListenerBuilder()
+                .addToListeners(DEFAULT_LISTENER_NAME, new VirtualClusterListenerBuilder()
                         .withClusterNetworkAddressConfigProvider(
                                 new ClusterNetworkAddressConfigProviderDefinitionBuilder(PortPerBrokerClusterNetworkAddressConfigProvider.class.getName())
                                         .withConfig("bootstrapAddress", defaultProxyBootstrap)

--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/test/tester/KroxyliciousTestersTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/test/tester/KroxyliciousTestersTest.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import io.kroxylicious.proxy.config.ClusterNetworkAddressConfigProviderDefinitionBuilder;
 import io.kroxylicious.proxy.config.ConfigurationBuilder;
 import io.kroxylicious.proxy.config.VirtualClusterBuilder;
+import io.kroxylicious.proxy.config.VirtualClusterListenerBuilder;
 import io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.PortPerBrokerClusterNetworkAddressConfigProvider;
 import io.kroxylicious.test.Request;
 import io.kroxylicious.test.ResponsePayload;
@@ -319,10 +320,12 @@ class KroxyliciousTestersTest {
                 .withNewTargetCluster()
                 .withBootstrapServers(clusterBootstrapServers)
                 .endTargetCluster()
-                .withClusterNetworkAddressConfigProvider(
-                        new ClusterNetworkAddressConfigProviderDefinitionBuilder(PortPerBrokerClusterNetworkAddressConfigProvider.class.getName())
-                                .withConfig("bootstrapAddress", defaultProxyBootstrap)
-                                .build())
+                .addToListeners("default", new VirtualClusterListenerBuilder()
+                        .withClusterNetworkAddressConfigProvider(
+                                new ClusterNetworkAddressConfigProviderDefinitionBuilder(PortPerBrokerClusterNetworkAddressConfigProvider.class.getName())
+                                        .withConfig("bootstrapAddress", defaultProxyBootstrap)
+                                        .build())
+                        .build())
                 .build());
     }
 

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/TlsIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/TlsIT.java
@@ -48,6 +48,7 @@ import io.kroxylicious.proxy.config.ClusterNetworkAddressConfigProviderDefinitio
 import io.kroxylicious.proxy.config.ClusterNetworkAddressConfigProviderDefinitionBuilder;
 import io.kroxylicious.proxy.config.ConfigurationBuilder;
 import io.kroxylicious.proxy.config.VirtualClusterBuilder;
+import io.kroxylicious.proxy.config.VirtualClusterListenerBuilder;
 import io.kroxylicious.proxy.config.secret.FilePassword;
 import io.kroxylicious.proxy.config.secret.InlinePassword;
 import io.kroxylicious.proxy.config.secret.PasswordProvider;
@@ -125,7 +126,9 @@ class TlsIT extends BaseIT {
                         .endTrustStoreTrust()
                         .endTls()
                         .endTargetCluster()
-                        .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
+                        .addToListeners("default", new VirtualClusterListenerBuilder()
+                                .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
+                                .build())
                         .build());
 
         try (var tester = kroxyliciousTester(builder); var admin = tester.admin("demo")) {
@@ -155,7 +158,9 @@ class TlsIT extends BaseIT {
                         .endTrustStoreTrust()
                         .endTls()
                         .endTargetCluster()
-                        .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
+                        .addToListeners("default", new VirtualClusterListenerBuilder()
+                                .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
+                                .build())
                         .build());
 
         try (var tester = kroxyliciousTester(builder); var admin = tester.admin("demo")) {
@@ -198,7 +203,9 @@ class TlsIT extends BaseIT {
                         .endTrustStoreTrust()
                         .endTls()
                         .endTargetCluster()
-                        .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
+                        .addToListeners("default", new VirtualClusterListenerBuilder()
+                                .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
+                                .build())
                         .build());
 
         try (var tester = kroxyliciousTester(builder); var admin = tester.admin("demo")) {
@@ -220,7 +227,9 @@ class TlsIT extends BaseIT {
                         .withNewInsecureTlsTrust(true)
                         .endTls()
                         .endTargetCluster()
-                        .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
+                        .addToListeners("default", new VirtualClusterListenerBuilder()
+                                .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
+                                .build())
                         .build());
 
         try (var tester = kroxyliciousTester(builder); var admin = tester.admin("demo")) {
@@ -279,7 +288,9 @@ class TlsIT extends BaseIT {
                             .endKeyStoreKey()
                             .endTls()
                             .endTargetCluster()
-                            .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
+                            .addToListeners("default", new VirtualClusterListenerBuilder()
+                                    .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
+                                    .build())
                             .build());
 
             try (var tester = kroxyliciousTester(builder); var admin = tester.admin("demo")) {
@@ -337,13 +348,15 @@ class TlsIT extends BaseIT {
                         .endTrustStoreTrust()
                         .endTls()
                         .endTargetCluster()
-                        .withNewTls()
-                        .withNewKeyStoreKey()
-                        .withStoreFile(proxyKeystoreLocation)
-                        .withStorePasswordProvider(proxyKeystorePasswordProvider)
-                        .endKeyStoreKey()
-                        .endTls()
-                        .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
+                        .addToListeners("default", new VirtualClusterListenerBuilder()
+                                .withNewTls()
+                                .withNewKeyStoreKey()
+                                .withStoreFile(proxyKeystoreLocation)
+                                .withStorePasswordProvider(proxyKeystorePasswordProvider)
+                                .endKeyStoreKey()
+                                .endTls()
+                                .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
+                                .build())
                         .build());
 
         try (var tester = kroxyliciousTester(builder);
@@ -369,14 +382,16 @@ class TlsIT extends BaseIT {
                         .withNewTargetCluster()
                         .withBootstrapServers(bootstrapServers)
                         .endTargetCluster()
-                        .withNewTls()
-                        .withNewKeyStoreKey()
-                        .withStoreFile(downstreamCertificateGenerator.getKeyStoreLocation())
-                        .withNewInlinePasswordStoreProvider(downstreamCertificateGenerator.getPassword())
-                        .endKeyStoreKey()
-                        .withProtocols(protocols)
-                        .endTls()
-                        .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
+                        .addToListeners("default", new VirtualClusterListenerBuilder()
+                                .withNewTls()
+                                .withNewKeyStoreKey()
+                                .withStoreFile(downstreamCertificateGenerator.getKeyStoreLocation())
+                                .withNewInlinePasswordStoreProvider(downstreamCertificateGenerator.getPassword())
+                                .endKeyStoreKey()
+                                .withProtocols(protocols)
+                                .endTls()
+                                .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
+                                .build())
                         .build());
 
         try (var tester = kroxyliciousTester(builder);
@@ -422,14 +437,16 @@ class TlsIT extends BaseIT {
                         .withNewTargetCluster()
                         .withBootstrapServers(bootstrapServers)
                         .endTargetCluster()
-                        .withNewTls()
-                        .withNewKeyStoreKey()
-                        .withStoreFile(downstreamCertificateGenerator.getKeyStoreLocation())
-                        .withNewInlinePasswordStoreProvider(downstreamCertificateGenerator.getPassword())
-                        .endKeyStoreKey()
-                        .withProtocols(protocols)
-                        .endTls()
-                        .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
+                        .addToListeners("default", new VirtualClusterListenerBuilder()
+                                .withNewTls()
+                                .withNewKeyStoreKey()
+                                .withStoreFile(downstreamCertificateGenerator.getKeyStoreLocation())
+                                .withNewInlinePasswordStoreProvider(downstreamCertificateGenerator.getPassword())
+                                .endKeyStoreKey()
+                                .withProtocols(protocols)
+                                .endTls()
+                                .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
+                                .build())
                         .build());
 
         try (var tester = kroxyliciousTester(builder);
@@ -458,14 +475,16 @@ class TlsIT extends BaseIT {
                         .withNewTargetCluster()
                         .withBootstrapServers(bootstrapServers)
                         .endTargetCluster()
-                        .withNewTls()
-                        .withNewKeyStoreKey()
-                        .withStoreFile(downstreamCertificateGenerator.getKeyStoreLocation())
-                        .withNewInlinePasswordStoreProvider(downstreamCertificateGenerator.getPassword())
-                        .endKeyStoreKey()
-                        .withProtocols(protocols)
-                        .endTls()
-                        .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
+                        .addToListeners("default", new VirtualClusterListenerBuilder()
+                                .withNewTls()
+                                .withNewKeyStoreKey()
+                                .withStoreFile(downstreamCertificateGenerator.getKeyStoreLocation())
+                                .withNewInlinePasswordStoreProvider(downstreamCertificateGenerator.getPassword())
+                                .endKeyStoreKey()
+                                .withProtocols(protocols)
+                                .endTls()
+                                .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
+                                .build())
                         .build());
 
         try (var tester = kroxyliciousTester(builder);
@@ -507,7 +526,9 @@ class TlsIT extends BaseIT {
                         .withProtocols(protocols)
                         .endTls()
                         .endTargetCluster()
-                        .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
+                        .addToListeners("default", new VirtualClusterListenerBuilder()
+                                .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
+                                .build())
                         .build());
 
         try (var tester = kroxyliciousTester(builder);
@@ -543,7 +564,9 @@ class TlsIT extends BaseIT {
                         .withProtocols(protocols)
                         .endTls()
                         .endTargetCluster()
-                        .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
+                        .addToListeners("default", new VirtualClusterListenerBuilder()
+                                .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
+                                .build())
                         .build());
 
         try (var tester = kroxyliciousTester(builder);
@@ -570,14 +593,16 @@ class TlsIT extends BaseIT {
                         .withNewTargetCluster()
                         .withBootstrapServers(bootstrapServers)
                         .endTargetCluster()
-                        .withNewTls()
-                        .withNewKeyStoreKey()
-                        .withStoreFile(downstreamCertificateGenerator.getKeyStoreLocation())
-                        .withNewInlinePasswordStoreProvider(downstreamCertificateGenerator.getPassword())
-                        .endKeyStoreKey()
-                        .withCipherSuites(cipherSuites)
-                        .endTls()
-                        .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
+                        .addToListeners("default", new VirtualClusterListenerBuilder()
+                                .withNewTls()
+                                .withNewKeyStoreKey()
+                                .withStoreFile(downstreamCertificateGenerator.getKeyStoreLocation())
+                                .withNewInlinePasswordStoreProvider(downstreamCertificateGenerator.getPassword())
+                                .endKeyStoreKey()
+                                .withCipherSuites(cipherSuites)
+                                .endTls()
+                                .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
+                                .build())
                         .build());
 
         try (var tester = kroxyliciousTester(builder);
@@ -622,14 +647,16 @@ class TlsIT extends BaseIT {
                         .withNewTargetCluster()
                         .withBootstrapServers(bootstrapServers)
                         .endTargetCluster()
-                        .withNewTls()
-                        .withNewKeyStoreKey()
-                        .withStoreFile(downstreamCertificateGenerator.getKeyStoreLocation())
-                        .withNewInlinePasswordStoreProvider(downstreamCertificateGenerator.getPassword())
-                        .endKeyStoreKey()
-                        .withCipherSuites(cipherSuites)
-                        .endTls()
-                        .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
+                        .addToListeners("default", new VirtualClusterListenerBuilder()
+                                .withNewTls()
+                                .withNewKeyStoreKey()
+                                .withStoreFile(downstreamCertificateGenerator.getKeyStoreLocation())
+                                .withNewInlinePasswordStoreProvider(downstreamCertificateGenerator.getPassword())
+                                .endKeyStoreKey()
+                                .withCipherSuites(cipherSuites)
+                                .endTls()
+                                .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
+                                .build())
                         .build());
 
         try (var tester = kroxyliciousTester(builder);
@@ -658,14 +685,16 @@ class TlsIT extends BaseIT {
                         .withNewTargetCluster()
                         .withBootstrapServers(bootstrapServers)
                         .endTargetCluster()
-                        .withNewTls()
-                        .withNewKeyStoreKey()
-                        .withStoreFile(downstreamCertificateGenerator.getKeyStoreLocation())
-                        .withNewInlinePasswordStoreProvider(downstreamCertificateGenerator.getPassword())
-                        .endKeyStoreKey()
-                        .withCipherSuites(cipherSuites)
-                        .endTls()
-                        .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
+                        .addToListeners("default", new VirtualClusterListenerBuilder()
+                                .withNewTls()
+                                .withNewKeyStoreKey()
+                                .withStoreFile(downstreamCertificateGenerator.getKeyStoreLocation())
+                                .withNewInlinePasswordStoreProvider(downstreamCertificateGenerator.getPassword())
+                                .endKeyStoreKey()
+                                .withCipherSuites(cipherSuites)
+                                .endTls()
+                                .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
+                                .build())
                         .build());
 
         try (var tester = kroxyliciousTester(builder);
@@ -707,7 +736,9 @@ class TlsIT extends BaseIT {
                         .withCipherSuites(cipherSuites)
                         .endTls()
                         .endTargetCluster()
-                        .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
+                        .addToListeners("default", new VirtualClusterListenerBuilder()
+                                .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
+                                .build())
                         .build());
 
         try (var tester = kroxyliciousTester(builder);
@@ -743,7 +774,9 @@ class TlsIT extends BaseIT {
                         .withCipherSuites(upstreamCipherSuites)
                         .endTls()
                         .endTargetCluster()
-                        .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
+                        .addToListeners("default", new VirtualClusterListenerBuilder()
+                                .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
+                                .build())
                         .build());
 
         try (var tester = kroxyliciousTester(builder);
@@ -856,20 +889,22 @@ class TlsIT extends BaseIT {
                         .withNewTargetCluster()
                         .withBootstrapServers(bootstrapServers)
                         .endTargetCluster()
-                        .withNewTls()
-                        .withNewKeyStoreKey()
-                        .withStoreFile(downstreamCertificateGenerator.getKeyStoreLocation())
-                        .withNewInlinePasswordStoreProvider(downstreamCertificateGenerator.getPassword())
-                        .endKeyStoreKey()
-                        .withNewTrustStoreTrust()
-                        .withNewServerOptionsTrust()
-                        .withClientAuth(tlsClientAuth)
-                        .endServerOptionsTrust()
-                        .withStoreFile(proxyTrustStore.toAbsolutePath().toString())
-                        .withNewInlinePasswordStoreProvider(clientCertGenerator.getPassword())
-                        .endTrustStoreTrust()
-                        .endTls()
-                        .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
+                        .addToListeners("default", new VirtualClusterListenerBuilder()
+                                .withNewTls()
+                                .withNewKeyStoreKey()
+                                .withStoreFile(downstreamCertificateGenerator.getKeyStoreLocation())
+                                .withNewInlinePasswordStoreProvider(downstreamCertificateGenerator.getPassword())
+                                .endKeyStoreKey()
+                                .withNewTrustStoreTrust()
+                                .withNewServerOptionsTrust()
+                                .withClientAuth(tlsClientAuth)
+                                .endServerOptionsTrust()
+                                .withStoreFile(proxyTrustStore.toAbsolutePath().toString())
+                                .withNewInlinePasswordStoreProvider(clientCertGenerator.getPassword())
+                                .endTrustStoreTrust()
+                                .endTls()
+                                .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
+                                .build())
                         .build());
     }
 

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/TlsIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/TlsIT.java
@@ -66,6 +66,7 @@ import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.DEFAULT_LISTENER_NAME;
 import static io.kroxylicious.test.tester.KroxyliciousTesters.kroxyliciousTester;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -126,7 +127,7 @@ class TlsIT extends BaseIT {
                         .endTrustStoreTrust()
                         .endTls()
                         .endTargetCluster()
-                        .addToListeners("default", new VirtualClusterListenerBuilder()
+                        .addToListeners(DEFAULT_LISTENER_NAME, new VirtualClusterListenerBuilder()
                                 .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
                                 .build())
                         .build());
@@ -158,7 +159,7 @@ class TlsIT extends BaseIT {
                         .endTrustStoreTrust()
                         .endTls()
                         .endTargetCluster()
-                        .addToListeners("default", new VirtualClusterListenerBuilder()
+                        .addToListeners(DEFAULT_LISTENER_NAME, new VirtualClusterListenerBuilder()
                                 .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
                                 .build())
                         .build());
@@ -203,7 +204,7 @@ class TlsIT extends BaseIT {
                         .endTrustStoreTrust()
                         .endTls()
                         .endTargetCluster()
-                        .addToListeners("default", new VirtualClusterListenerBuilder()
+                        .addToListeners(DEFAULT_LISTENER_NAME, new VirtualClusterListenerBuilder()
                                 .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
                                 .build())
                         .build());
@@ -227,7 +228,7 @@ class TlsIT extends BaseIT {
                         .withNewInsecureTlsTrust(true)
                         .endTls()
                         .endTargetCluster()
-                        .addToListeners("default", new VirtualClusterListenerBuilder()
+                        .addToListeners(DEFAULT_LISTENER_NAME, new VirtualClusterListenerBuilder()
                                 .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
                                 .build())
                         .build());
@@ -288,7 +289,7 @@ class TlsIT extends BaseIT {
                             .endKeyStoreKey()
                             .endTls()
                             .endTargetCluster()
-                            .addToListeners("default", new VirtualClusterListenerBuilder()
+                            .addToListeners(DEFAULT_LISTENER_NAME, new VirtualClusterListenerBuilder()
                                     .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
                                     .build())
                             .build());
@@ -348,7 +349,7 @@ class TlsIT extends BaseIT {
                         .endTrustStoreTrust()
                         .endTls()
                         .endTargetCluster()
-                        .addToListeners("default", new VirtualClusterListenerBuilder()
+                        .addToListeners(DEFAULT_LISTENER_NAME, new VirtualClusterListenerBuilder()
                                 .withNewTls()
                                 .withNewKeyStoreKey()
                                 .withStoreFile(proxyKeystoreLocation)
@@ -382,7 +383,7 @@ class TlsIT extends BaseIT {
                         .withNewTargetCluster()
                         .withBootstrapServers(bootstrapServers)
                         .endTargetCluster()
-                        .addToListeners("default", new VirtualClusterListenerBuilder()
+                        .addToListeners(DEFAULT_LISTENER_NAME, new VirtualClusterListenerBuilder()
                                 .withNewTls()
                                 .withNewKeyStoreKey()
                                 .withStoreFile(downstreamCertificateGenerator.getKeyStoreLocation())
@@ -437,7 +438,7 @@ class TlsIT extends BaseIT {
                         .withNewTargetCluster()
                         .withBootstrapServers(bootstrapServers)
                         .endTargetCluster()
-                        .addToListeners("default", new VirtualClusterListenerBuilder()
+                        .addToListeners(DEFAULT_LISTENER_NAME, new VirtualClusterListenerBuilder()
                                 .withNewTls()
                                 .withNewKeyStoreKey()
                                 .withStoreFile(downstreamCertificateGenerator.getKeyStoreLocation())
@@ -475,7 +476,7 @@ class TlsIT extends BaseIT {
                         .withNewTargetCluster()
                         .withBootstrapServers(bootstrapServers)
                         .endTargetCluster()
-                        .addToListeners("default", new VirtualClusterListenerBuilder()
+                        .addToListeners(DEFAULT_LISTENER_NAME, new VirtualClusterListenerBuilder()
                                 .withNewTls()
                                 .withNewKeyStoreKey()
                                 .withStoreFile(downstreamCertificateGenerator.getKeyStoreLocation())
@@ -526,7 +527,7 @@ class TlsIT extends BaseIT {
                         .withProtocols(protocols)
                         .endTls()
                         .endTargetCluster()
-                        .addToListeners("default", new VirtualClusterListenerBuilder()
+                        .addToListeners(DEFAULT_LISTENER_NAME, new VirtualClusterListenerBuilder()
                                 .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
                                 .build())
                         .build());
@@ -564,7 +565,7 @@ class TlsIT extends BaseIT {
                         .withProtocols(protocols)
                         .endTls()
                         .endTargetCluster()
-                        .addToListeners("default", new VirtualClusterListenerBuilder()
+                        .addToListeners(DEFAULT_LISTENER_NAME, new VirtualClusterListenerBuilder()
                                 .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
                                 .build())
                         .build());
@@ -593,7 +594,7 @@ class TlsIT extends BaseIT {
                         .withNewTargetCluster()
                         .withBootstrapServers(bootstrapServers)
                         .endTargetCluster()
-                        .addToListeners("default", new VirtualClusterListenerBuilder()
+                        .addToListeners(DEFAULT_LISTENER_NAME, new VirtualClusterListenerBuilder()
                                 .withNewTls()
                                 .withNewKeyStoreKey()
                                 .withStoreFile(downstreamCertificateGenerator.getKeyStoreLocation())
@@ -647,7 +648,7 @@ class TlsIT extends BaseIT {
                         .withNewTargetCluster()
                         .withBootstrapServers(bootstrapServers)
                         .endTargetCluster()
-                        .addToListeners("default", new VirtualClusterListenerBuilder()
+                        .addToListeners(DEFAULT_LISTENER_NAME, new VirtualClusterListenerBuilder()
                                 .withNewTls()
                                 .withNewKeyStoreKey()
                                 .withStoreFile(downstreamCertificateGenerator.getKeyStoreLocation())
@@ -685,7 +686,7 @@ class TlsIT extends BaseIT {
                         .withNewTargetCluster()
                         .withBootstrapServers(bootstrapServers)
                         .endTargetCluster()
-                        .addToListeners("default", new VirtualClusterListenerBuilder()
+                        .addToListeners(DEFAULT_LISTENER_NAME, new VirtualClusterListenerBuilder()
                                 .withNewTls()
                                 .withNewKeyStoreKey()
                                 .withStoreFile(downstreamCertificateGenerator.getKeyStoreLocation())
@@ -736,7 +737,7 @@ class TlsIT extends BaseIT {
                         .withCipherSuites(cipherSuites)
                         .endTls()
                         .endTargetCluster()
-                        .addToListeners("default", new VirtualClusterListenerBuilder()
+                        .addToListeners(DEFAULT_LISTENER_NAME, new VirtualClusterListenerBuilder()
                                 .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
                                 .build())
                         .build());
@@ -774,7 +775,7 @@ class TlsIT extends BaseIT {
                         .withCipherSuites(upstreamCipherSuites)
                         .endTls()
                         .endTargetCluster()
-                        .addToListeners("default", new VirtualClusterListenerBuilder()
+                        .addToListeners(DEFAULT_LISTENER_NAME, new VirtualClusterListenerBuilder()
                                 .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
                                 .build())
                         .build());
@@ -889,7 +890,7 @@ class TlsIT extends BaseIT {
                         .withNewTargetCluster()
                         .withBootstrapServers(bootstrapServers)
                         .endTargetCluster()
-                        .addToListeners("default", new VirtualClusterListenerBuilder()
+                        .addToListeners(DEFAULT_LISTENER_NAME, new VirtualClusterListenerBuilder()
                                 .withNewTls()
                                 .withNewKeyStoreKey()
                                 .withStoreFile(downstreamCertificateGenerator.getKeyStoreLocation())

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/multitenant/BaseMultiTenantIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/multitenant/BaseMultiTenantIT.java
@@ -54,6 +54,7 @@ import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.DEFAULT_LISTENER_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
@@ -106,7 +107,7 @@ public abstract class BaseMultiTenantIT extends BaseIT {
                         .withNewTargetCluster()
                         .withBootstrapServers(cluster.getBootstrapServers())
                         .endTargetCluster()
-                        .addToListeners("default", new VirtualClusterListenerBuilder()
+                        .addToListeners(DEFAULT_LISTENER_NAME, new VirtualClusterListenerBuilder()
                                 .withClusterNetworkAddressConfigProvider(
                                         new ClusterNetworkAddressConfigProviderDefinitionBuilder(PortPerBrokerClusterNetworkAddressConfigProvider.class.getName())
                                                 .withConfig("bootstrapAddress", TENANT_1_PROXY_ADDRESS)
@@ -123,7 +124,7 @@ public abstract class BaseMultiTenantIT extends BaseIT {
                         .withNewTargetCluster()
                         .withBootstrapServers(cluster.getBootstrapServers())
                         .endTargetCluster()
-                        .addToListeners("default", new VirtualClusterListenerBuilder()
+                        .addToListeners(DEFAULT_LISTENER_NAME, new VirtualClusterListenerBuilder()
                                 .withClusterNetworkAddressConfigProvider(
                                         new ClusterNetworkAddressConfigProviderDefinitionBuilder(PortPerBrokerClusterNetworkAddressConfigProvider.class.getName())
                                                 .withConfig("bootstrapAddress", TENANT_2_PROXY_ADDRESS)

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/multitenant/BaseMultiTenantIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/multitenant/BaseMultiTenantIT.java
@@ -43,6 +43,7 @@ import io.kroxylicious.proxy.config.ClusterNetworkAddressConfigProviderDefinitio
 import io.kroxylicious.proxy.config.ConfigurationBuilder;
 import io.kroxylicious.proxy.config.NamedFilterDefinitionBuilder;
 import io.kroxylicious.proxy.config.VirtualClusterBuilder;
+import io.kroxylicious.proxy.config.VirtualClusterListenerBuilder;
 import io.kroxylicious.proxy.filter.multitenant.MultiTenant;
 import io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.PortPerBrokerClusterNetworkAddressConfigProvider;
 import io.kroxylicious.proxy.service.HostPort;
@@ -105,31 +106,35 @@ public abstract class BaseMultiTenantIT extends BaseIT {
                         .withNewTargetCluster()
                         .withBootstrapServers(cluster.getBootstrapServers())
                         .endTargetCluster()
-                        .withClusterNetworkAddressConfigProvider(
-                                new ClusterNetworkAddressConfigProviderDefinitionBuilder(PortPerBrokerClusterNetworkAddressConfigProvider.class.getName())
-                                        .withConfig("bootstrapAddress", TENANT_1_PROXY_ADDRESS)
-                                        .build())
-                        .withNewTls()
-                        .withNewKeyStoreKey()
-                        .withStoreFile(certificateGenerator.getKeyStoreLocation())
-                        .withNewInlinePasswordStoreProvider(certificateGenerator.getPassword())
-                        .endKeyStoreKey()
-                        .endTls()
+                        .addToListeners("default", new VirtualClusterListenerBuilder()
+                                .withClusterNetworkAddressConfigProvider(
+                                        new ClusterNetworkAddressConfigProviderDefinitionBuilder(PortPerBrokerClusterNetworkAddressConfigProvider.class.getName())
+                                                .withConfig("bootstrapAddress", TENANT_1_PROXY_ADDRESS)
+                                                .build())
+                                .withNewTls()
+                                .withNewKeyStoreKey()
+                                .withStoreFile(certificateGenerator.getKeyStoreLocation())
+                                .withNewInlinePasswordStoreProvider(certificateGenerator.getPassword())
+                                .endKeyStoreKey()
+                                .endTls()
+                                .build())
                         .build())
                 .addToVirtualClusters(TENANT_2_CLUSTER, new VirtualClusterBuilder()
                         .withNewTargetCluster()
                         .withBootstrapServers(cluster.getBootstrapServers())
                         .endTargetCluster()
-                        .withClusterNetworkAddressConfigProvider(
-                                new ClusterNetworkAddressConfigProviderDefinitionBuilder(PortPerBrokerClusterNetworkAddressConfigProvider.class.getName())
-                                        .withConfig("bootstrapAddress", TENANT_2_PROXY_ADDRESS)
-                                        .build())
-                        .withNewTls()
-                        .withNewKeyStoreKey()
-                        .withStoreFile(certificateGenerator.getKeyStoreLocation())
-                        .withNewInlinePasswordStoreProvider(certificateGenerator.getPassword())
-                        .endKeyStoreKey()
-                        .endTls()
+                        .addToListeners("default", new VirtualClusterListenerBuilder()
+                                .withClusterNetworkAddressConfigProvider(
+                                        new ClusterNetworkAddressConfigProviderDefinitionBuilder(PortPerBrokerClusterNetworkAddressConfigProvider.class.getName())
+                                                .withConfig("bootstrapAddress", TENANT_2_PROXY_ADDRESS)
+                                                .build())
+                                .withNewTls()
+                                .withNewKeyStoreKey()
+                                .withStoreFile(certificateGenerator.getKeyStoreLocation())
+                                .withNewInlinePasswordStoreProvider(certificateGenerator.getPassword())
+                                .endKeyStoreKey()
+                                .endTls()
+                                .build())
                         .build())
                 .addToFilterDefinitions(filterBuilder.build())
                 .addToDefaultFilters(filterBuilder.name());

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyConfigSecret.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyConfigSecret.java
@@ -35,6 +35,7 @@ import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.config.NamedFilterDefinition;
 import io.kroxylicious.proxy.config.TargetCluster;
 import io.kroxylicious.proxy.config.VirtualCluster;
+import io.kroxylicious.proxy.config.VirtualClusterListener;
 import io.kroxylicious.proxy.config.admin.AdminHttpConfiguration;
 import io.kroxylicious.proxy.config.admin.EndpointsConfiguration;
 import io.kroxylicious.proxy.config.admin.PrometheusMetricsConfig;
@@ -212,7 +213,9 @@ public class ProxyConfigSecret
 
         return new VirtualCluster(
                 new TargetCluster(cluster.getUpstream().getBootstrapServers(), Optional.empty()),
-                new ClusterNetworkAddressConfigProviderDefinition(
+                null,
+                Optional.empty(),
+                Map.of("default", new VirtualClusterListener(new ClusterNetworkAddressConfigProviderDefinition(
                         "PortPerBrokerClusterNetworkAddressConfigProvider",
                         new PortPerBrokerClusterNetworkAddressConfigProvider.PortPerBrokerClusterNetworkAddressConfigProviderConfig(
                                 new HostPort("localhost", 9292 + (100 * clusterNum)),
@@ -220,8 +223,7 @@ public class ProxyConfigSecret
                                 null,
                                 null,
                                 null)),
-                Optional.empty(),
-                Map.of(),
+                        Optional.empty())),
                 false, false,
                 filterNamesForCluster(cluster));
     }

--- a/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/filter-resource-not-found/out-Secret-example.yaml
+++ b/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/filter-resource-not-found/out-Secret-example.yaml
@@ -41,13 +41,15 @@ stringData:
       bar:
         targetCluster:
           bootstrapServers: "my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092"
-        clusterNetworkAddressConfigProvider:
-          type: "PortPerBrokerClusterNetworkAddressConfigProvider"
-          config:
-            bootstrapAddress: "localhost:9392"
-            brokerAddressPattern: "bar.proxy-ns.svc.cluster.local"
-            brokerStartPort: 9393
-            numberOfBrokerPorts: 3
+        listeners:
+          default:
+            clusterNetworkAddressConfigProvider:
+              type: "PortPerBrokerClusterNetworkAddressConfigProvider"
+              config:
+                bootstrapAddress: "localhost:9392"
+                brokerAddressPattern: "bar.proxy-ns.svc.cluster.local"
+                brokerStartPort: 9393
+                numberOfBrokerPorts: 3
         filters:
         - "filter-one.Filter.filter.kroxylicious.io"
         - "filter-two.Filter.filter.kroxylicious.io"

--- a/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/minimal/out-Secret-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/minimal/out-Secret-minimal.yaml
@@ -32,10 +32,12 @@ stringData:
       one:
         targetCluster:
           bootstrapServers: "my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092"
-        clusterNetworkAddressConfigProvider:
-          type: "PortPerBrokerClusterNetworkAddressConfigProvider"
-          config:
-            bootstrapAddress: "localhost:9292"
-            brokerAddressPattern: "one.proxy-ns.svc.cluster.local"
-            brokerStartPort: 9293
-            numberOfBrokerPorts: 3
+        listeners:
+          default:
+            clusterNetworkAddressConfigProvider:
+              type: "PortPerBrokerClusterNetworkAddressConfigProvider"
+              config:
+                bootstrapAddress: "localhost:9292"
+                brokerAddressPattern: "one.proxy-ns.svc.cluster.local"
+                brokerStartPort: 9293
+                numberOfBrokerPorts: 3

--- a/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/two-clusters/out-Secret-twocluster.yaml
+++ b/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/two-clusters/out-Secret-twocluster.yaml
@@ -32,20 +32,24 @@ stringData:
       foo:
         targetCluster:
           bootstrapServers: "first-kafka.kafka1.svc.cluster.local:9092"
-        clusterNetworkAddressConfigProvider:
-          type: "PortPerBrokerClusterNetworkAddressConfigProvider"
-          config:
-            bootstrapAddress: "localhost:9292"
-            brokerAddressPattern: "foo.proxy-ns.svc.cluster.local"
-            brokerStartPort: 9293
-            numberOfBrokerPorts: 3
+        listeners:
+          default:
+            clusterNetworkAddressConfigProvider:
+              type: "PortPerBrokerClusterNetworkAddressConfigProvider"
+              config:
+                bootstrapAddress: "localhost:9292"
+                brokerAddressPattern: "foo.proxy-ns.svc.cluster.local"
+                brokerStartPort: 9293
+                numberOfBrokerPorts: 3
       bar:
         targetCluster:
           bootstrapServers: "second-kafka.kafka2.svc.cluster.local:9092"
-        clusterNetworkAddressConfigProvider:
-          type: "PortPerBrokerClusterNetworkAddressConfigProvider"
-          config:
-            bootstrapAddress: "localhost:9392"
-            brokerAddressPattern: "bar.proxy-ns.svc.cluster.local"
-            brokerStartPort: 9393
-            numberOfBrokerPorts: 3
+        listeners:
+          default:
+            clusterNetworkAddressConfigProvider:
+              type: "PortPerBrokerClusterNetworkAddressConfigProvider"
+              config:
+                bootstrapAddress: "localhost:9392"
+                brokerAddressPattern: "bar.proxy-ns.svc.cluster.local"
+                brokerStartPort: 9393
+                numberOfBrokerPorts: 3

--- a/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/two-filters/out-Secret-example.yaml
+++ b/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/two-filters/out-Secret-example.yaml
@@ -41,13 +41,15 @@ stringData:
       foo:
         targetCluster:
           bootstrapServers: "my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092"
-        clusterNetworkAddressConfigProvider:
-          type: "PortPerBrokerClusterNetworkAddressConfigProvider"
-          config:
-            bootstrapAddress: "localhost:9292"
-            brokerAddressPattern: "foo.proxy-ns.svc.cluster.local"
-            brokerStartPort: 9293
-            numberOfBrokerPorts: 3
+        listeners:
+          default:
+            clusterNetworkAddressConfigProvider:
+              type: "PortPerBrokerClusterNetworkAddressConfigProvider"
+              config:
+                bootstrapAddress: "localhost:9292"
+                brokerAddressPattern: "foo.proxy-ns.svc.cluster.local"
+                brokerStartPort: 9293
+                numberOfBrokerPorts: 3
         filters:
         - "filter-one.Filter.filter.kroxylicious.io"
         - "filter-two.Filter.filter.kroxylicious.io"

--- a/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/use-pod-template-spec/out-Secret-use-pod-template-spec.yaml
+++ b/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/use-pod-template-spec/out-Secret-use-pod-template-spec.yaml
@@ -32,10 +32,12 @@ stringData:
       one:
         targetCluster:
           bootstrapServers: "my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092"
-        clusterNetworkAddressConfigProvider:
-          type: "PortPerBrokerClusterNetworkAddressConfigProvider"
-          config:
-            bootstrapAddress: "localhost:9292"
-            brokerAddressPattern: "one.proxy-ns.svc.cluster.local"
-            brokerStartPort: 9293
-            numberOfBrokerPorts: 3
+        listeners:
+          default:
+            clusterNetworkAddressConfigProvider:
+              type: "PortPerBrokerClusterNetworkAddressConfigProvider"
+              config:
+                bootstrapAddress: "localhost:9292"
+                brokerAddressPattern: "one.proxy-ns.svc.cluster.local"
+                brokerStartPort: 9293
+                numberOfBrokerPorts: 3

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/VirtualCluster.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/VirtualCluster.java
@@ -55,12 +55,4 @@ public record VirtualCluster(TargetCluster targetCluster,
         }
     }
 
-    public ClusterNetworkAddressConfigProviderDefinition clusterNetworkAddressConfigProvider() {
-        throw new UnsupportedOperationException();
-    }
-
-    public Optional<Tls> tls() {
-        throw new UnsupportedOperationException();
-    }
-
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/PortConflictDetector.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/PortConflictDetector.java
@@ -17,8 +17,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import io.kroxylicious.proxy.internal.net.EndpointListener;
 import io.kroxylicious.proxy.model.VirtualClusterModel;
-import io.kroxylicious.proxy.model.VirtualClusterModel.VirtualClusterListenerModel;
 import io.kroxylicious.proxy.service.HostPort;
 
 /**
@@ -99,7 +99,7 @@ public class PortConflictDetector {
     }
 
     private void assertSharedPortsHaveMatchingTlsConfiguration(Set<String> seenVirtualClusters, Map<Optional<String>, Map<Integer, Boolean>> inUseSharedPorts,
-                                                               VirtualClusterListenerModel virtualClusterModel, String name,
+                                                               EndpointListener virtualClusterModel, String name,
                                                                Set<Integer> proposedSharedPorts) {
         proposedSharedPorts.forEach(p -> {
             var tls = inUseSharedPorts.getOrDefault(virtualClusterModel.getBindAddress(), Map.of()).get(p);
@@ -110,7 +110,7 @@ public class PortConflictDetector {
     }
 
     private void assertSharedPortsAreExclusiveAcrossInterfaces(Set<String> seenVirtualClusters, Map<Optional<String>, Map<Integer, Boolean>> inUseSharedPorts,
-                                                               VirtualClusterListenerModel virtualClusterModel, String name,
+                                                               EndpointListener virtualClusterModel, String name,
                                                                Set<Integer> proposedSharedPorts, Set<Optional<String>> exclusiveCheckSet) {
         var sharedCheckSet = new HashSet<>(exclusiveCheckSet);
         sharedCheckSet.remove(virtualClusterModel.getBindAddress());
@@ -130,7 +130,7 @@ public class PortConflictDetector {
     }
 
     private void assertExclusivePortsDoNotOverlapWithExclusivePorts(Set<String> seenVirtualClusters, Map<Optional<String>, Map<Integer, Boolean>> inUseSharedPorts,
-                                                                    VirtualClusterListenerModel virtualClusterModel, String name,
+                                                                    EndpointListener virtualClusterModel, String name,
                                                                     Set<Integer> proposedExclusivePorts, Set<Optional<String>> exclusiveCheckSet) {
         inUseSharedPorts.entrySet().stream()
                 .filter(interfacePortsEntry -> exclusiveCheckSet.contains(interfacePortsEntry.getKey()))
@@ -147,7 +147,7 @@ public class PortConflictDetector {
     }
 
     private void assertSharedPortsDoNotOverlapWithExlusivePorts(Set<String> seenVirtualClusters, Map<Optional<String>, Set<Integer>> inUseExclusivePorts,
-                                                                VirtualClusterListenerModel virtualClusterModel, String name,
+                                                                EndpointListener virtualClusterModel, String name,
                                                                 Set<Integer> proposedSharedPorts, Set<Optional<String>> exclusiveCheckSet) {
         inUseExclusivePorts.entrySet().stream()
                 .filter(interfacePortsEntry -> exclusiveCheckSet.contains(interfacePortsEntry.getKey()))
@@ -164,7 +164,7 @@ public class PortConflictDetector {
     }
 
     private void assertExclusivePortsAreMutuallyExclusive(Set<String> seenVirtualClusters, Map<Optional<String>, Set<Integer>> inUseExclusivePorts,
-                                                          VirtualClusterListenerModel virtualClusterModel, String name,
+                                                          EndpointListener virtualClusterModel, String name,
                                                           Set<Integer> proposedExclusivePorts, Set<Optional<String>> exclusiveCheckSet) {
         inUseExclusivePorts.entrySet().stream()
                 .filter(interfacePortsEntry -> exclusiveCheckSet.contains(interfacePortsEntry.getKey()))
@@ -180,7 +180,7 @@ public class PortConflictDetector {
                 });
     }
 
-    private void checkForConflictsWithOtherExclusivePort(HostPort otherHostPort, String name, VirtualClusterListenerModel cluster, Set<Integer> proposedExclusivePorts,
+    private void checkForConflictsWithOtherExclusivePort(HostPort otherHostPort, String name, EndpointListener cluster, Set<Integer> proposedExclusivePorts,
                                                          BindingScope scope) {
         var ports = Set.of(otherHostPort.port());
         var conflicts = getSortedPortConflicts(ports, proposedExclusivePorts);

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/filter/BrokerAddressFilter.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/filter/BrokerAddressFilter.java
@@ -37,8 +37,8 @@ import io.kroxylicious.proxy.filter.ProduceResponseFilter;
 import io.kroxylicious.proxy.filter.ResponseFilterResult;
 import io.kroxylicious.proxy.filter.ShareAcknowledgeResponseFilter;
 import io.kroxylicious.proxy.filter.ShareFetchResponseFilter;
+import io.kroxylicious.proxy.internal.net.EndpointListener;
 import io.kroxylicious.proxy.internal.net.EndpointReconciler;
-import io.kroxylicious.proxy.model.VirtualClusterModel.VirtualClusterListenerModel;
 import io.kroxylicious.proxy.service.HostPort;
 
 /**
@@ -50,10 +50,10 @@ public class BrokerAddressFilter implements MetadataResponseFilter, FindCoordina
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BrokerAddressFilter.class);
 
-    private final VirtualClusterListenerModel listenerModel;
+    private final EndpointListener listenerModel;
     private final EndpointReconciler reconciler;
 
-    public BrokerAddressFilter(VirtualClusterListenerModel listenerModel, EndpointReconciler reconciler) {
+    public BrokerAddressFilter(EndpointListener listenerModel, EndpointReconciler reconciler) {
         this.listenerModel = listenerModel;
         this.reconciler = reconciler;
     }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/EndpointListener.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/EndpointListener.java
@@ -8,8 +8,12 @@ package io.kroxylicious.proxy.internal.net;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+
+import io.netty.handler.ssl.SslContext;
 
 import io.kroxylicious.proxy.config.TargetCluster;
+import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.service.HostPort;
 
 /**
@@ -35,6 +39,8 @@ public interface EndpointListener {
      */
     boolean requiresTls();
 
+    VirtualClusterModel virtualCluster();
+
     /**
      * Bootstrap address.
      *
@@ -50,6 +56,8 @@ public interface EndpointListener {
      * @throws IllegalArgumentException address for given broker node cannot be generated.
      */
     HostPort getBrokerAddress(int nodeId) throws IllegalArgumentException;
+
+    Optional<SslContext> getDownstreamSslContext();
 
     /**
      * Advertised address of broker with the given node id, (advertised hostname and advertised port). This is
@@ -70,6 +78,10 @@ public interface EndpointListener {
      */
     Optional<String> getBindAddress();
 
+    Set<Integer> getExclusivePorts();
+
+    Set<Integer> getSharedPorts();
+
     /**
      * Map of node ids to broker addresses.
      *
@@ -89,4 +101,5 @@ public interface EndpointListener {
      * @return broker id
      */
     Integer getBrokerIdFromBrokerAddress(HostPort brokerAddress);
+
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
@@ -57,7 +57,7 @@ public class VirtualClusterModel {
 
     private final boolean logFrames;
 
-    private final Map<String, VirtualClusterListenerModel> listeners = new HashMap<>();
+    private final Map<String, EndpointListener> listeners = new HashMap<>();
 
     private final List<NamedFilterDefinition> filters;
 
@@ -232,7 +232,7 @@ public class VirtualClusterModel {
         return filters;
     }
 
-    public Map<String, VirtualClusterListenerModel> listeners() {
+    public Map<String, EndpointListener> listeners() {
         return Collections.unmodifiableMap(listeners);
     }
 
@@ -252,6 +252,7 @@ public class VirtualClusterModel {
 
         }
 
+        @Override
         public VirtualClusterModel virtualCluster() {
             return virtualCluster;
         }
@@ -293,10 +294,12 @@ public class VirtualClusterModel {
             return getClusterNetworkAddressConfigProvider().requiresTls();
         }
 
+        @Override
         public Set<Integer> getExclusivePorts() {
             return getClusterNetworkAddressConfigProvider().getExclusivePorts();
         }
 
+        @Override
         public Set<Integer> getSharedPorts() {
             return getClusterNetworkAddressConfigProvider().getSharedPorts();
         }
@@ -309,6 +312,7 @@ public class VirtualClusterModel {
             return getClusterNetworkAddressConfigProvider().getBrokerIdFromBrokerAddress(brokerAddress);
         }
 
+        @Override
         public Optional<SslContext> getDownstreamSslContext() {
             return downstreamSslContext;
         }


### PR DESCRIPTION
1. Refactor to use EndpointListener interface further, fix classcast exceptions in ProxyInitializer, adds `getVirtualCluster()` to EndpointListener.
2. Update example YAML to new format
3. Use new listener syntax in integration tests
4. Validate VirtualCluster configuration (covers more incorrect configurations like legacy tls supplied with no provider, null value in the listeners map)
5. Add simple multi-listener exposition IT (refactors the test clients so that we can get a per-listener Admin client)
6. Add kroxylicious tester methods to get per-listener clients (adds the ability to get Producer/Consumer per listener)
7. updates Operator to use the new format