### PR TITLE
refactor: introduce method for default listener builder

### DIFF
--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/proxy/config/ConfigurationTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/proxy/config/ConfigurationTest.java
@@ -28,7 +28,8 @@ import io.kroxylicious.proxy.config.tls.TlsClientAuth;
 import io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.PortPerBrokerClusterNetworkAddressConfigProvider;
 import io.kroxylicious.proxy.service.HostPort;
 
-import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.DEFAULT_LISTENER_NAME;
+import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.defaultListenerBuilder;
+import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.defaultSniListenerBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.params.provider.Arguments.argumentSet;
@@ -36,7 +37,7 @@ import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 class ConfigurationTest {
 
     private static final ObjectMapper MAPPER = new ObjectMapper(new YAMLFactory()).registerModule(new Jdk8Module());
-    private static final VirtualClusterListener VIRTUAL_CLUSTER_LISTENER = new VirtualClusterListenerBuilder().withName(DEFAULT_LISTENER_NAME)
+    private static final VirtualClusterListener VIRTUAL_CLUSTER_LISTENER = defaultListenerBuilder()
             .withClusterNetworkAddressConfigProvider(
                     new ClusterNetworkAddressConfigProviderDefinition("unused", null))
             .build();
@@ -276,8 +277,7 @@ class ConfigurationTest {
                                 .addToVirtualClusters("demo", new VirtualClusterBuilder()
                                         .withNewTargetCluster()
                                         .withBootstrapServers("kafka.example:1234")
-                                        .endTargetCluster().addToListeners(new VirtualClusterListenerBuilder()
-                                                .withName(DEFAULT_LISTENER_NAME)
+                                        .endTargetCluster().addToListeners(defaultListenerBuilder()
                                                 .withClusterNetworkAddressConfigProvider(
                                                         new ClusterNetworkAddressConfigProviderDefinitionBuilder("SniRoutingClusterNetworkAddressConfigProvider")
                                                                 .withConfig(
@@ -304,14 +304,7 @@ class ConfigurationTest {
                                 .addToVirtualClusters("demo", new VirtualClusterBuilder()
                                         .withNewTargetCluster()
                                         .withBootstrapServers("kafka.example:1234")
-                                        .endTargetCluster().addToListeners(new VirtualClusterListenerBuilder()
-                                                .withName(DEFAULT_LISTENER_NAME)
-                                                .withClusterNetworkAddressConfigProvider(
-                                                        new ClusterNetworkAddressConfigProviderDefinitionBuilder("SniRoutingClusterNetworkAddressConfigProvider")
-                                                                .withConfig(
-                                                                        "bootstrapAddress", "cluster1:9192", "advertisedBrokerAddressPattern", "broker-$(nodeId)")
-                                                                .build())
-                                                .build())
+                                        .endTargetCluster().addToListeners(defaultSniListenerBuilder("cluster1:9192", "broker-$(nodeId)").build())
                                         .build())
                                 .build(),
                         """
@@ -378,13 +371,7 @@ class ConfigurationTest {
                                         .withNewTargetCluster()
                                         .withBootstrapServers("kafka.example:1234")
                                         .endTargetCluster()
-                                        .addToListeners(new VirtualClusterListenerBuilder()
-                                                .withName(DEFAULT_LISTENER_NAME)
-                                                .withClusterNetworkAddressConfigProvider(
-                                                        new ClusterNetworkAddressConfigProviderDefinitionBuilder("SniRoutingClusterNetworkAddressConfigProvider")
-                                                                .withConfig(
-                                                                        "bootstrapAddress", "cluster1:9192", "advertisedBrokerAddressPattern", "broker-$(nodeId)")
-                                                                .build())
+                                        .addToListeners(defaultSniListenerBuilder("cluster1:9192", "broker-$(nodeId)")
                                                 .withNewTls()
                                                 .withNewKeyPairKey()
                                                 .withCertificateFile("/tmp/cert")
@@ -420,13 +407,7 @@ class ConfigurationTest {
                                         .withNewTargetCluster()
                                         .withBootstrapServers("kafka.example:1234")
                                         .endTargetCluster()
-                                        .addToListeners(new VirtualClusterListenerBuilder()
-                                                .withName(DEFAULT_LISTENER_NAME)
-                                                .withClusterNetworkAddressConfigProvider(
-                                                        new ClusterNetworkAddressConfigProviderDefinitionBuilder("SniRoutingClusterNetworkAddressConfigProvider")
-                                                                .withConfig(
-                                                                        "bootstrapAddress", "cluster1:9192", "advertisedBrokerAddressPattern", "broker-$(nodeId)")
-                                                                .build())
+                                        .addToListeners(defaultSniListenerBuilder("cluster1:9192", "broker-$(nodeId)")
                                                 .withNewTls()
                                                 .withNewKeyPairKey()
                                                 .withCertificateFile("/tmp/cert")
@@ -473,14 +454,7 @@ class ConfigurationTest {
                                         .withNewTls()
                                         .endTls()
                                         .endTargetCluster()
-                                        .addToListeners(new VirtualClusterListenerBuilder()
-                                                .withName(DEFAULT_LISTENER_NAME)
-                                                .withClusterNetworkAddressConfigProvider(
-                                                        new ClusterNetworkAddressConfigProviderDefinitionBuilder(
-                                                                "SniRoutingClusterNetworkAddressConfigProvider")
-                                                                .withConfig("bootstrapAddress", "cluster1:9192", "advertisedBrokerAddressPattern", "broker-$(nodeId)")
-                                                                .build())
-                                                .build())
+                                        .addToListeners(defaultSniListenerBuilder("cluster1:9192", "broker-$(nodeId)").build())
                                         .build())
                                 .build(),
                         """
@@ -510,14 +484,7 @@ class ConfigurationTest {
                                         .endTrustStoreTrust()
                                         .endTls()
                                         .endTargetCluster()
-                                        .addToListeners(new VirtualClusterListenerBuilder()
-                                                .withName(DEFAULT_LISTENER_NAME)
-                                                .withClusterNetworkAddressConfigProvider(
-                                                        new ClusterNetworkAddressConfigProviderDefinitionBuilder(
-                                                                "SniRoutingClusterNetworkAddressConfigProvider")
-                                                                .withConfig("bootstrapAddress", "cluster1:9192", "advertisedBrokerAddressPattern", "broker-$(nodeId)")
-                                                                .build())
-                                                .build())
+                                        .addToListeners(defaultSniListenerBuilder("cluster1:9192", "broker-$(nodeId)").build())
                                         .build())
                                 .build(),
                         """
@@ -552,14 +519,7 @@ class ConfigurationTest {
                                         .endTrustStoreTrust()
                                         .endTls()
                                         .endTargetCluster()
-                                        .addToListeners(new VirtualClusterListenerBuilder()
-                                                .withName(DEFAULT_LISTENER_NAME)
-                                                .withClusterNetworkAddressConfigProvider(
-                                                        new ClusterNetworkAddressConfigProviderDefinitionBuilder(
-                                                                "SniRoutingClusterNetworkAddressConfigProvider")
-                                                                .withConfig("bootstrapAddress", "cluster1:9192", "advertisedBrokerAddressPattern", "broker-$(nodeId)")
-                                                                .build())
-                                                .build())
+                                        .addToListeners(defaultSniListenerBuilder("cluster1:9192", "broker-$(nodeId)").build())
                                         .build())
                                 .build(),
                         """
@@ -590,14 +550,7 @@ class ConfigurationTest {
                                         .withNewInsecureTlsTrust(true)
                                         .endTls()
                                         .endTargetCluster()
-                                        .addToListeners(new VirtualClusterListenerBuilder()
-                                                .withName(DEFAULT_LISTENER_NAME)
-                                                .withClusterNetworkAddressConfigProvider(
-                                                        new ClusterNetworkAddressConfigProviderDefinitionBuilder(
-                                                                "SniRoutingClusterNetworkAddressConfigProvider")
-                                                                .withConfig("bootstrapAddress", "cluster1:9192", "advertisedBrokerAddressPattern", "broker-$(nodeId)")
-                                                                .build())
-                                                .build())
+                                        .addToListeners(defaultSniListenerBuilder("cluster1:9192", "broker-$(nodeId)").build())
                                         .build())
                                 .build(),
                         """

--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/test/tester/DefaultKroxyliciousTesterTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/test/tester/DefaultKroxyliciousTesterTest.java
@@ -50,6 +50,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.DEFAULT_LISTENER_NAME;
 import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.DEFAULT_PROXY_BOOTSTRAP;
 import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.DEFAULT_VIRTUAL_CLUSTER;
+import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.defaultPortPerBrokerListenerBuilder;
 import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.proxy;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -619,13 +620,7 @@ class DefaultKroxyliciousTesterTest {
                 .withNewTargetCluster()
                 .withBootstrapServers(backingCluster)
                 .endTargetCluster()
-                .addToListeners(new VirtualClusterListenerBuilder()
-                        .withName(DEFAULT_LISTENER_NAME)
-                        .withClusterNetworkAddressConfigProvider(
-                                new ClusterNetworkAddressConfigProviderDefinitionBuilder(PortPerBrokerClusterNetworkAddressConfigProvider.class.getName())
-                                        .withConfig("bootstrapAddress", new HostPort(DEFAULT_PROXY_BOOTSTRAP.host(), DEFAULT_PROXY_BOOTSTRAP.port()))
-                                        .build())
-                        .build())
+                .addToListeners(defaultPortPerBrokerListenerBuilder(DEFAULT_PROXY_BOOTSTRAP).build())
                 .addToListeners(new VirtualClusterListenerBuilder()
                         .withName(CUSTOM_LISTENER_NAME)
                         .withClusterNetworkAddressConfigProvider(
@@ -649,17 +644,13 @@ class DefaultKroxyliciousTesterTest {
                 .withNewTargetCluster()
                 .withBootstrapServers(backingCluster)
                 .endTargetCluster()
-                .addToListeners(new VirtualClusterListenerBuilder()
-                        .withName(DEFAULT_LISTENER_NAME)
+                .addToListeners(defaultPortPerBrokerListenerBuilder(DEFAULT_PROXY_BOOTSTRAP)
                         .withNewTls()
                         .withNewKeyStoreKey()
                         .withStoreFile(keytoolCertificateGenerator.getKeyStoreLocation())
                         .withNewInlinePasswordStoreProvider(keytoolCertificateGenerator.getPassword())
                         .endKeyStoreKey()
                         .endTls()
-                        .withClusterNetworkAddressConfigProvider(
-                                new ClusterNetworkAddressConfigProviderDefinitionBuilder(PortPerBrokerClusterNetworkAddressConfigProvider.class.getName())
-                                        .withConfig("bootstrapAddress", DEFAULT_PROXY_BOOTSTRAP).build())
                         .build());
         configurationBuilder
                 .addToVirtualClusters(TLS_CLUSTER, vcb.build());

--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/test/tester/KroxyliciousTestersTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/test/tester/KroxyliciousTestersTest.java
@@ -34,11 +34,9 @@ import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import io.kroxylicious.proxy.config.ClusterNetworkAddressConfigProviderDefinitionBuilder;
 import io.kroxylicious.proxy.config.ConfigurationBuilder;
 import io.kroxylicious.proxy.config.VirtualClusterBuilder;
-import io.kroxylicious.proxy.config.VirtualClusterListenerBuilder;
-import io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.PortPerBrokerClusterNetworkAddressConfigProvider;
+import io.kroxylicious.proxy.service.HostPort;
 import io.kroxylicious.test.Request;
 import io.kroxylicious.test.ResponsePayload;
 import io.kroxylicious.test.client.KafkaClient;
@@ -50,8 +48,8 @@ import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
-import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.DEFAULT_LISTENER_NAME;
 import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.DEFAULT_VIRTUAL_CLUSTER;
+import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.defaultPortPerBrokerListenerBuilder;
 import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.proxy;
 import static io.kroxylicious.test.tester.KroxyliciousTesters.kroxyliciousTester;
 import static io.kroxylicious.test.tester.KroxyliciousTesters.mockKafkaKroxyliciousTester;
@@ -321,13 +319,7 @@ class KroxyliciousTestersTest {
                 .withNewTargetCluster()
                 .withBootstrapServers(clusterBootstrapServers)
                 .endTargetCluster()
-                .addToListeners(new VirtualClusterListenerBuilder()
-                        .withName(DEFAULT_LISTENER_NAME)
-                        .withClusterNetworkAddressConfigProvider(
-                                new ClusterNetworkAddressConfigProviderDefinitionBuilder(PortPerBrokerClusterNetworkAddressConfigProvider.class.getName())
-                                        .withConfig("bootstrapAddress", defaultProxyBootstrap)
-                                        .build())
-                        .build())
+                .addToListeners(defaultPortPerBrokerListenerBuilder(HostPort.parse(defaultProxyBootstrap)).build())
                 .build());
     }
 

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/ExpositionIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/ExpositionIT.java
@@ -58,6 +58,7 @@ import io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.RangeA
 import io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.RangeAwarePortPerNodeClusterNetworkAddressConfigProvider.NamedRangeSpec;
 import io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.SniRoutingClusterNetworkAddressConfigProvider;
 import io.kroxylicious.proxy.service.HostPort;
+import io.kroxylicious.test.tester.KroxyliciousConfigUtils;
 import io.kroxylicious.test.tester.KroxyliciousTester;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.clients.CloseableAdmin;
@@ -70,6 +71,9 @@ import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.DEFAULT_LISTENER_NAME;
+import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.defaultListenerBuilder;
+import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.defaultPortPerBrokerListenerBuilder;
+import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.defaultSniListenerBuilder;
 import static io.kroxylicious.test.tester.KroxyliciousTesters.kroxyliciousTester;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
@@ -208,13 +212,7 @@ class ExpositionIT extends BaseIT {
             var keystoreTrustStorePair = buildKeystoreTrustStorePair("*" + virtualClusterCommonNamePattern);
 
             var virtualCluster = baseVirtualClusterBuilder(cluster)
-                    .addToListeners(new VirtualClusterListenerBuilder()
-                            .withName(DEFAULT_LISTENER_NAME)
-                            .withClusterNetworkAddressConfigProvider(
-                                    new ClusterNetworkAddressConfigProviderDefinitionBuilder(SniRoutingClusterNetworkAddressConfigProvider.class.getName())
-                                            .withConfig("bootstrapAddress", virtualClusterBootstrapPattern + ":9192",
-                                                    "advertisedBrokerAddressPattern", virtualClusterBrokerAddressPattern + ":" + proxy.getLocalPort())
-                                            .build())
+                    .addToListeners(defaultSniListenerBuilder(virtualClusterBootstrapPattern + ":9192", virtualClusterBrokerAddressPattern + ":" + proxy.getLocalPort())
                             .withNewTls()
                             .withNewKeyStoreKey()
                             .withStoreFile(keystoreTrustStorePair.brokerKeyStore())
@@ -260,13 +258,7 @@ class ExpositionIT extends BaseIT {
             keystoreTrustStoreList.add(keystoreTrustStorePair);
 
             var virtualCluster = baseVirtualClusterBuilder(cluster)
-                    .addToListeners(new VirtualClusterListenerBuilder()
-                            .withName(DEFAULT_LISTENER_NAME)
-                            .withClusterNetworkAddressConfigProvider(
-                                    new ClusterNetworkAddressConfigProviderDefinitionBuilder(SniRoutingClusterNetworkAddressConfigProvider.class.getName())
-                                            .withConfig("bootstrapAddress", virtualClusterFQDN + ":9192",
-                                                    brokerPatternProp, virtualClusterBrokerAddressPattern.formatted(i))
-                                            .build())
+                    .addToListeners(defaultSniListenerBuilder(virtualClusterFQDN + ":9192", virtualClusterBrokerAddressPattern.formatted(i))
                             .withNewTls()
                             .withNewKeyStoreKey()
                             .withStoreFile(keystoreTrustStorePair.brokerKeyStore())
@@ -301,8 +293,7 @@ class ExpositionIT extends BaseIT {
                         .withNewTargetCluster()
                         .withBootstrapServers(cluster.getBootstrapServers())
                         .endTargetCluster()
-                        .addToListeners(new VirtualClusterListenerBuilder()
-                                .withName(DEFAULT_LISTENER_NAME)
+                        .addToListeners(defaultListenerBuilder()
                                 .withClusterNetworkAddressConfigProvider(
                                         new ClusterNetworkAddressConfigProviderDefinitionBuilder(RangeAwarePortPerNodeClusterNetworkAddressConfigProvider.class.getName())
                                                 .withConfig("bootstrapAddress", PROXY_ADDRESS)
@@ -335,8 +326,7 @@ class ExpositionIT extends BaseIT {
                         .withNewTargetCluster()
                         .withBootstrapServers(cluster.getBootstrapServers())
                         .endTargetCluster()
-                        .addToListeners(new VirtualClusterListenerBuilder()
-                                .withName(DEFAULT_LISTENER_NAME)
+                        .addToListeners(defaultListenerBuilder()
                                 .withClusterNetworkAddressConfigProvider(
                                         new ClusterNetworkAddressConfigProviderDefinitionBuilder(RangeAwarePortPerNodeClusterNetworkAddressConfigProvider.class.getName())
                                                 .withConfig("bootstrapAddress", PROXY_ADDRESS)
@@ -364,18 +354,13 @@ class ExpositionIT extends BaseIT {
 
     @Test
     void exposesClusterOfTwoBrokers(@BrokerCluster(numBrokers = 2) KafkaCluster cluster) throws Exception {
+        HostPort proxyAddress = PROXY_ADDRESS;
         var builder = new ConfigurationBuilder()
                 .addToVirtualClusters("demo", new VirtualClusterBuilder()
                         .withNewTargetCluster()
                         .withBootstrapServers(cluster.getBootstrapServers())
                         .endTargetCluster()
-                        .addToListeners(new VirtualClusterListenerBuilder()
-                                .withName(DEFAULT_LISTENER_NAME)
-                                .withClusterNetworkAddressConfigProvider(
-                                        new ClusterNetworkAddressConfigProviderDefinitionBuilder(PortPerBrokerClusterNetworkAddressConfigProvider.class.getName())
-                                                .withConfig("bootstrapAddress", PROXY_ADDRESS)
-                                                .build())
-                                .build())
+                        .addToListeners(KroxyliciousConfigUtils.defaultPortPerBrokerListenerBuilder(proxyAddress).build())
                         .build());
 
         var brokerEndpoints = Map.of(0, "localhost:" + (PROXY_ADDRESS.port() + 1), 1, "localhost:" + (PROXY_ADDRESS.port() + 2));
@@ -402,19 +387,13 @@ class ExpositionIT extends BaseIT {
                         new VirtualClusterBuilder()
                                 .withNewTargetCluster()
                                 .endTargetCluster()
-                                .addToListeners(new VirtualClusterListenerBuilder()
-                                        .withName(DEFAULT_LISTENER_NAME)
+                                .addToListeners(defaultPortPerBrokerListenerBuilder(PROXY_ADDRESS)
                                         .withNewTls()
                                         .withNewKeyStoreKey()
                                         .withStoreFile(portPerBrokerKeystoreTrustStorePair.brokerKeyStore())
                                         .withNewInlinePasswordStoreProvider(portPerBrokerKeystoreTrustStorePair.password())
                                         .endKeyStoreKey()
                                         .endTls()
-                                        .withClusterNetworkAddressConfigProvider(
-                                                new ClusterNetworkAddressConfigProviderDefinitionBuilder(
-                                                        PortPerBrokerClusterNetworkAddressConfigProvider.class.getName())
-                                                        .withConfig("bootstrapAddress", PROXY_ADDRESS)
-                                                        .build())
                                         .build()),
                         Map.of(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SSL.name,
                                 SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, portPerBrokerKeystoreTrustStorePair.clientTrustStore(),
@@ -423,20 +402,13 @@ class ExpositionIT extends BaseIT {
                         new VirtualClusterBuilder()
                                 .withNewTargetCluster()
                                 .endTargetCluster()
-                                .addToListeners(new VirtualClusterListenerBuilder()
-                                        .withName(DEFAULT_LISTENER_NAME)
+                                .addToListeners(defaultSniListenerBuilder(SNI_BOOTSTRAP.toString(), SNI_BROKER_ADDRESS_PATTERN)
                                         .withNewTls()
                                         .withNewKeyStoreKey()
                                         .withStoreFile(sniKeystoreTrustStorePair.brokerKeyStore())
                                         .withNewInlinePasswordStoreProvider(sniKeystoreTrustStorePair.password())
                                         .endKeyStoreKey()
                                         .endTls()
-                                        .withClusterNetworkAddressConfigProvider(
-                                                new ClusterNetworkAddressConfigProviderDefinitionBuilder(
-                                                        SniRoutingClusterNetworkAddressConfigProvider.class.getName())
-                                                        .withConfig("bootstrapAddress", SNI_BOOTSTRAP)
-                                                        .withConfig("advertisedBrokerAddressPattern", SNI_BROKER_ADDRESS_PATTERN)
-                                                        .build())
                                         .build()),
                         Map.of(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SSL.name,
                                 SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, sniKeystoreTrustStorePair.clientTrustStore(),
@@ -546,7 +518,7 @@ class ExpositionIT extends BaseIT {
 
         final HostPort discoveryBrokerAddressToProbe;
         ClusterNetworkAddressConfigProviderDefinition provider = virtualClusterBuilder.buildFirstListener().clusterNetworkAddressConfigProvider();
-        if (provider.type().equals(SniRoutingClusterNetworkAddressConfigProvider.class.getName())) {
+        if (provider.type().equals(SniRoutingClusterNetworkAddressConfigProvider.class.getSimpleName())) {
             discoveryBrokerAddressToProbe = new HostPort(SNI_BROKER_ADDRESS_PATTERN.replace("$(nodeId)", Integer.toString(cluster.getNumOfBrokers())),
                     SNI_BOOTSTRAP.port());
         }
@@ -597,12 +569,7 @@ class ExpositionIT extends BaseIT {
                         .withNewTargetCluster()
                         .withBootstrapServers(cluster.getBootstrapServers())
                         .endTargetCluster()
-                        .addToListeners(new VirtualClusterListenerBuilder()
-                                .withName(DEFAULT_LISTENER_NAME)
-                                .withClusterNetworkAddressConfigProvider(
-                                        new ClusterNetworkAddressConfigProviderDefinitionBuilder(PortPerBrokerClusterNetworkAddressConfigProvider.class.getName())
-                                                .withConfig("bootstrapAddress", PROXY_ADDRESS)
-                                                .build())
+                        .addToListeners(KroxyliciousConfigUtils.defaultPortPerBrokerListenerBuilder(PROXY_ADDRESS)
                                 .build())
                         .build());
 
@@ -638,8 +605,7 @@ class ExpositionIT extends BaseIT {
                         .withNewTargetCluster()
                         .withBootstrapServers(cluster.getBootstrapServers())
                         .endTargetCluster()
-                        .addToListeners(new VirtualClusterListenerBuilder()
-                                .withName(DEFAULT_LISTENER_NAME)
+                        .addToListeners(defaultListenerBuilder()
                                 .withClusterNetworkAddressConfigProvider(
                                         new ClusterNetworkAddressConfigProviderDefinitionBuilder(PortPerBrokerClusterNetworkAddressConfigProvider.class.getName())
                                                 .withConfig("bootstrapAddress", PROXY_ADDRESS)
@@ -662,12 +628,7 @@ class ExpositionIT extends BaseIT {
                         .withNewTargetCluster()
                         .withBootstrapServers(cluster.getBootstrapServers())
                         .endTargetCluster()
-                        .addToListeners(new VirtualClusterListenerBuilder()
-                                .withName(DEFAULT_LISTENER_NAME)
-                                .withClusterNetworkAddressConfigProvider(
-                                        new ClusterNetworkAddressConfigProviderDefinitionBuilder(PortPerBrokerClusterNetworkAddressConfigProvider.class.getName())
-                                                .withConfig("bootstrapAddress", PROXY_ADDRESS)
-                                                .build())
+                        .addToListeners(KroxyliciousConfigUtils.defaultPortPerBrokerListenerBuilder(PROXY_ADDRESS)
                                 .build())
                         .build());
 

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/TlsIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/TlsIT.java
@@ -44,17 +44,13 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import io.kroxylicious.proxy.config.ClusterNetworkAddressConfigProviderDefinition;
-import io.kroxylicious.proxy.config.ClusterNetworkAddressConfigProviderDefinitionBuilder;
 import io.kroxylicious.proxy.config.ConfigurationBuilder;
 import io.kroxylicious.proxy.config.VirtualClusterBuilder;
-import io.kroxylicious.proxy.config.VirtualClusterListenerBuilder;
 import io.kroxylicious.proxy.config.secret.FilePassword;
 import io.kroxylicious.proxy.config.secret.InlinePassword;
 import io.kroxylicious.proxy.config.secret.PasswordProvider;
 import io.kroxylicious.proxy.config.tls.AllowDeny;
 import io.kroxylicious.proxy.config.tls.TlsClientAuth;
-import io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.PortPerBrokerClusterNetworkAddressConfigProvider;
 import io.kroxylicious.proxy.service.HostPort;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.clients.CloseableAdmin;
@@ -66,7 +62,7 @@ import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
-import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.DEFAULT_LISTENER_NAME;
+import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.defaultPortPerBrokerListenerBuilder;
 import static io.kroxylicious.test.tester.KroxyliciousTesters.kroxyliciousTester;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -79,10 +75,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @ExtendWith(KafkaClusterExtension.class)
 class TlsIT extends BaseIT {
     private static final HostPort PROXY_ADDRESS = HostPort.parse("localhost:9192");
-    private static final ClusterNetworkAddressConfigProviderDefinition CONFIG_PROVIDER_DEFINITION = new ClusterNetworkAddressConfigProviderDefinitionBuilder(
-            PortPerBrokerClusterNetworkAddressConfigProvider.class.getName())
-            .withConfig("bootstrapAddress", PROXY_ADDRESS)
-            .build();
     private static final String TOPIC = "my-test-topic";
     @TempDir
     private Path certsDirectory;
@@ -127,9 +119,7 @@ class TlsIT extends BaseIT {
                         .endTrustStoreTrust()
                         .endTls()
                         .endTargetCluster()
-                        .addToListeners(new VirtualClusterListenerBuilder()
-                                .withName(DEFAULT_LISTENER_NAME)
-                                .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
+                        .addToListeners(defaultPortPerBrokerListenerBuilder(PROXY_ADDRESS)
                                 .build())
                         .build());
 
@@ -160,9 +150,7 @@ class TlsIT extends BaseIT {
                         .endTrustStoreTrust()
                         .endTls()
                         .endTargetCluster()
-                        .addToListeners(new VirtualClusterListenerBuilder()
-                                .withName(DEFAULT_LISTENER_NAME)
-                                .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
+                        .addToListeners(defaultPortPerBrokerListenerBuilder(PROXY_ADDRESS)
                                 .build())
                         .build());
 
@@ -206,9 +194,7 @@ class TlsIT extends BaseIT {
                         .endTrustStoreTrust()
                         .endTls()
                         .endTargetCluster()
-                        .addToListeners(new VirtualClusterListenerBuilder()
-                                .withName(DEFAULT_LISTENER_NAME)
-                                .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
+                        .addToListeners(defaultPortPerBrokerListenerBuilder(PROXY_ADDRESS)
                                 .build())
                         .build());
 
@@ -231,10 +217,7 @@ class TlsIT extends BaseIT {
                         .withNewInsecureTlsTrust(true)
                         .endTls()
                         .endTargetCluster()
-                        .addToListeners(new VirtualClusterListenerBuilder()
-                                .withName(DEFAULT_LISTENER_NAME)
-                                .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
-                                .build())
+                        .addToListeners(defaultPortPerBrokerListenerBuilder(PROXY_ADDRESS).build())
                         .build());
 
         try (var tester = kroxyliciousTester(builder); var admin = tester.admin("demo")) {
@@ -293,10 +276,7 @@ class TlsIT extends BaseIT {
                             .endKeyStoreKey()
                             .endTls()
                             .endTargetCluster()
-                            .addToListeners(new VirtualClusterListenerBuilder()
-                                    .withName(DEFAULT_LISTENER_NAME)
-                                    .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
-                                    .build())
+                            .addToListeners(defaultPortPerBrokerListenerBuilder(PROXY_ADDRESS).build())
                             .build());
 
             try (var tester = kroxyliciousTester(builder); var admin = tester.admin("demo")) {
@@ -354,15 +334,13 @@ class TlsIT extends BaseIT {
                         .endTrustStoreTrust()
                         .endTls()
                         .endTargetCluster()
-                        .addToListeners(new VirtualClusterListenerBuilder()
-                                .withName(DEFAULT_LISTENER_NAME)
+                        .addToListeners(defaultPortPerBrokerListenerBuilder(PROXY_ADDRESS)
                                 .withNewTls()
                                 .withNewKeyStoreKey()
                                 .withStoreFile(proxyKeystoreLocation)
                                 .withStorePasswordProvider(proxyKeystorePasswordProvider)
                                 .endKeyStoreKey()
                                 .endTls()
-                                .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
                                 .build())
                         .build());
 
@@ -389,8 +367,7 @@ class TlsIT extends BaseIT {
                         .withNewTargetCluster()
                         .withBootstrapServers(bootstrapServers)
                         .endTargetCluster()
-                        .addToListeners(new VirtualClusterListenerBuilder()
-                                .withName(DEFAULT_LISTENER_NAME)
+                        .addToListeners(defaultPortPerBrokerListenerBuilder(PROXY_ADDRESS)
                                 .withNewTls()
                                 .withNewKeyStoreKey()
                                 .withStoreFile(downstreamCertificateGenerator.getKeyStoreLocation())
@@ -398,7 +375,6 @@ class TlsIT extends BaseIT {
                                 .endKeyStoreKey()
                                 .withProtocols(protocols)
                                 .endTls()
-                                .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
                                 .build())
                         .build());
 
@@ -445,8 +421,7 @@ class TlsIT extends BaseIT {
                         .withNewTargetCluster()
                         .withBootstrapServers(bootstrapServers)
                         .endTargetCluster()
-                        .addToListeners(new VirtualClusterListenerBuilder()
-                                .withName(DEFAULT_LISTENER_NAME)
+                        .addToListeners(defaultPortPerBrokerListenerBuilder(PROXY_ADDRESS)
                                 .withNewTls()
                                 .withNewKeyStoreKey()
                                 .withStoreFile(downstreamCertificateGenerator.getKeyStoreLocation())
@@ -454,7 +429,6 @@ class TlsIT extends BaseIT {
                                 .endKeyStoreKey()
                                 .withProtocols(protocols)
                                 .endTls()
-                                .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
                                 .build())
                         .build());
 
@@ -484,8 +458,7 @@ class TlsIT extends BaseIT {
                         .withNewTargetCluster()
                         .withBootstrapServers(bootstrapServers)
                         .endTargetCluster()
-                        .addToListeners(new VirtualClusterListenerBuilder()
-                                .withName(DEFAULT_LISTENER_NAME)
+                        .addToListeners(defaultPortPerBrokerListenerBuilder(PROXY_ADDRESS)
                                 .withNewTls()
                                 .withNewKeyStoreKey()
                                 .withStoreFile(downstreamCertificateGenerator.getKeyStoreLocation())
@@ -493,7 +466,6 @@ class TlsIT extends BaseIT {
                                 .endKeyStoreKey()
                                 .withProtocols(protocols)
                                 .endTls()
-                                .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
                                 .build())
                         .build());
 
@@ -536,10 +508,7 @@ class TlsIT extends BaseIT {
                         .withProtocols(protocols)
                         .endTls()
                         .endTargetCluster()
-                        .addToListeners(new VirtualClusterListenerBuilder()
-                                .withName(DEFAULT_LISTENER_NAME)
-                                .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
-                                .build())
+                        .addToListeners(defaultPortPerBrokerListenerBuilder(PROXY_ADDRESS).build())
                         .build());
 
         try (var tester = kroxyliciousTester(builder);
@@ -575,10 +544,7 @@ class TlsIT extends BaseIT {
                         .withProtocols(protocols)
                         .endTls()
                         .endTargetCluster()
-                        .addToListeners(new VirtualClusterListenerBuilder()
-                                .withName(DEFAULT_LISTENER_NAME)
-                                .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
-                                .build())
+                        .addToListeners(defaultPortPerBrokerListenerBuilder(PROXY_ADDRESS).build())
                         .build());
 
         try (var tester = kroxyliciousTester(builder);
@@ -605,8 +571,7 @@ class TlsIT extends BaseIT {
                         .withNewTargetCluster()
                         .withBootstrapServers(bootstrapServers)
                         .endTargetCluster()
-                        .addToListeners(new VirtualClusterListenerBuilder()
-                                .withName(DEFAULT_LISTENER_NAME)
+                        .addToListeners(defaultPortPerBrokerListenerBuilder(PROXY_ADDRESS)
                                 .withNewTls()
                                 .withNewKeyStoreKey()
                                 .withStoreFile(downstreamCertificateGenerator.getKeyStoreLocation())
@@ -614,7 +579,6 @@ class TlsIT extends BaseIT {
                                 .endKeyStoreKey()
                                 .withCipherSuites(cipherSuites)
                                 .endTls()
-                                .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
                                 .build())
                         .build());
 
@@ -660,8 +624,7 @@ class TlsIT extends BaseIT {
                         .withNewTargetCluster()
                         .withBootstrapServers(bootstrapServers)
                         .endTargetCluster()
-                        .addToListeners(new VirtualClusterListenerBuilder()
-                                .withName(DEFAULT_LISTENER_NAME)
+                        .addToListeners(defaultPortPerBrokerListenerBuilder(PROXY_ADDRESS)
                                 .withNewTls()
                                 .withNewKeyStoreKey()
                                 .withStoreFile(downstreamCertificateGenerator.getKeyStoreLocation())
@@ -669,7 +632,6 @@ class TlsIT extends BaseIT {
                                 .endKeyStoreKey()
                                 .withCipherSuites(cipherSuites)
                                 .endTls()
-                                .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
                                 .build())
                         .build());
 
@@ -699,8 +661,7 @@ class TlsIT extends BaseIT {
                         .withNewTargetCluster()
                         .withBootstrapServers(bootstrapServers)
                         .endTargetCluster()
-                        .addToListeners(new VirtualClusterListenerBuilder()
-                                .withName(DEFAULT_LISTENER_NAME)
+                        .addToListeners(defaultPortPerBrokerListenerBuilder(PROXY_ADDRESS)
                                 .withNewTls()
                                 .withNewKeyStoreKey()
                                 .withStoreFile(downstreamCertificateGenerator.getKeyStoreLocation())
@@ -708,7 +669,6 @@ class TlsIT extends BaseIT {
                                 .endKeyStoreKey()
                                 .withCipherSuites(cipherSuites)
                                 .endTls()
-                                .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
                                 .build())
                         .build());
 
@@ -751,10 +711,7 @@ class TlsIT extends BaseIT {
                         .withCipherSuites(cipherSuites)
                         .endTls()
                         .endTargetCluster()
-                        .addToListeners(new VirtualClusterListenerBuilder()
-                                .withName(DEFAULT_LISTENER_NAME)
-                                .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
-                                .build())
+                        .addToListeners(defaultPortPerBrokerListenerBuilder(PROXY_ADDRESS).build())
                         .build());
 
         try (var tester = kroxyliciousTester(builder);
@@ -790,10 +747,7 @@ class TlsIT extends BaseIT {
                         .withCipherSuites(upstreamCipherSuites)
                         .endTls()
                         .endTargetCluster()
-                        .addToListeners(new VirtualClusterListenerBuilder()
-                                .withName(DEFAULT_LISTENER_NAME)
-                                .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
-                                .build())
+                        .addToListeners(defaultPortPerBrokerListenerBuilder(PROXY_ADDRESS).build())
                         .build());
 
         try (var tester = kroxyliciousTester(builder);
@@ -906,8 +860,7 @@ class TlsIT extends BaseIT {
                         .withNewTargetCluster()
                         .withBootstrapServers(bootstrapServers)
                         .endTargetCluster()
-                        .addToListeners(new VirtualClusterListenerBuilder()
-                                .withName(DEFAULT_LISTENER_NAME)
+                        .addToListeners(defaultPortPerBrokerListenerBuilder(PROXY_ADDRESS)
                                 .withNewTls()
                                 .withNewKeyStoreKey()
                                 .withStoreFile(downstreamCertificateGenerator.getKeyStoreLocation())
@@ -921,7 +874,6 @@ class TlsIT extends BaseIT {
                                 .withNewInlinePasswordStoreProvider(clientCertGenerator.getPassword())
                                 .endTrustStoreTrust()
                                 .endTls()
-                                .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
                                 .build())
                         .build());
     }

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/multitenant/BaseMultiTenantIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/multitenant/BaseMultiTenantIT.java
@@ -39,13 +39,10 @@ import org.junit.jupiter.api.io.TempDir;
 
 import io.kroxylicious.net.IntegrationTestInetAddressResolverProvider;
 import io.kroxylicious.proxy.BaseIT;
-import io.kroxylicious.proxy.config.ClusterNetworkAddressConfigProviderDefinitionBuilder;
 import io.kroxylicious.proxy.config.ConfigurationBuilder;
 import io.kroxylicious.proxy.config.NamedFilterDefinitionBuilder;
 import io.kroxylicious.proxy.config.VirtualClusterBuilder;
-import io.kroxylicious.proxy.config.VirtualClusterListenerBuilder;
 import io.kroxylicious.proxy.filter.multitenant.MultiTenant;
-import io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.PortPerBrokerClusterNetworkAddressConfigProvider;
 import io.kroxylicious.proxy.service.HostPort;
 import io.kroxylicious.test.tester.KroxyliciousTester;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
@@ -54,7 +51,7 @@ import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
-import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.DEFAULT_LISTENER_NAME;
+import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.defaultPortPerBrokerListenerBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
@@ -107,12 +104,7 @@ public abstract class BaseMultiTenantIT extends BaseIT {
                         .withNewTargetCluster()
                         .withBootstrapServers(cluster.getBootstrapServers())
                         .endTargetCluster()
-                        .addToListeners(new VirtualClusterListenerBuilder()
-                                .withName(DEFAULT_LISTENER_NAME)
-                                .withClusterNetworkAddressConfigProvider(
-                                        new ClusterNetworkAddressConfigProviderDefinitionBuilder(PortPerBrokerClusterNetworkAddressConfigProvider.class.getName())
-                                                .withConfig("bootstrapAddress", TENANT_1_PROXY_ADDRESS)
-                                                .build())
+                        .addToListeners(defaultPortPerBrokerListenerBuilder(TENANT_1_PROXY_ADDRESS)
                                 .withNewTls()
                                 .withNewKeyStoreKey()
                                 .withStoreFile(certificateGenerator.getKeyStoreLocation())
@@ -125,12 +117,7 @@ public abstract class BaseMultiTenantIT extends BaseIT {
                         .withNewTargetCluster()
                         .withBootstrapServers(cluster.getBootstrapServers())
                         .endTargetCluster()
-                        .addToListeners(new VirtualClusterListenerBuilder()
-                                .withName(DEFAULT_LISTENER_NAME)
-                                .withClusterNetworkAddressConfigProvider(
-                                        new ClusterNetworkAddressConfigProviderDefinitionBuilder(PortPerBrokerClusterNetworkAddressConfigProvider.class.getName())
-                                                .withConfig("bootstrapAddress", TENANT_2_PROXY_ADDRESS)
-                                                .build())
+                        .addToListeners(defaultPortPerBrokerListenerBuilder(TENANT_2_PROXY_ADDRESS)
                                 .withNewTls()
                                 .withNewKeyStoreKey()
                                 .withStoreFile(certificateGenerator.getKeyStoreLocation())


### PR DESCRIPTION
Refactor to add some integration test methods for creating the listener builders, saving some repetition and preventing the "default" listener naming detail leaking out into as many tests.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
