### PR TITLE
PortConflictDetector exceptions include listener name

### DIFF
--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/EndpointListener.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/EndpointListener.java
@@ -100,4 +100,10 @@ public interface EndpointListener {
      */
     Integer getBrokerIdFromBrokerAddress(HostPort brokerAddress);
 
+    /**
+     * Get the listeners name
+     * @return name
+     */
+    String name();
+
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
@@ -118,7 +118,7 @@ public class VirtualClusterModel {
     public void addListener(String name, ClusterNetworkAddressConfigProvider provider, Optional<Tls> tls) {
         validateTLsSettings(provider, tls);
         validatePortUsage(provider);
-        listeners.put(name, new VirtualClusterListenerModel(this, provider, tls));
+        listeners.put(name, new VirtualClusterListenerModel(this, provider, tls, name));
     }
 
     public TargetCluster targetCluster() {
@@ -279,13 +279,15 @@ public class VirtualClusterModel {
         private final ClusterNetworkAddressConfigProvider provider;
         private final Optional<Tls> tls;
         private final Optional<SslContext> downstreamSslContext;
+        private final String name;
 
         @VisibleForTesting
-        VirtualClusterListenerModel(VirtualClusterModel virtualCluster, ClusterNetworkAddressConfigProvider provider, Optional<Tls> tls) {
+        VirtualClusterListenerModel(VirtualClusterModel virtualCluster, ClusterNetworkAddressConfigProvider provider, Optional<Tls> tls, String name) {
             this.virtualCluster = virtualCluster;
             this.provider = provider;
             this.tls = tls;
             this.downstreamSslContext = buildDownstreamSslContext();
+            this.name = name;
         }
 
         @Override
@@ -343,6 +345,11 @@ public class VirtualClusterModel {
         }
 
         @Override
+        public String name() {
+            return name;
+        }
+
+        @Override
         public HostPort getAdvertisedBrokerAddress(int nodeId) {
             return getClusterNetworkAddressConfigProvider().getAdvertisedBrokerAddress(nodeId);
         }
@@ -382,6 +389,7 @@ public class VirtualClusterModel {
         public String toString() {
             return "VirtualClusterListenerModel[" +
                     "virtualCluster=" + virtualCluster + ", " +
+                    "name=" + name + ", " +
                     "provider=" + provider + ", " +
                     "tls=" + tls + ']';
         }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/PortConflictDetectorTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/PortConflictDetectorTest.java
@@ -10,7 +10,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -43,132 +42,147 @@ class PortConflictDetectorTest {
         var privateUse = "192.168.0.1";
         return Stream.of(
                 argumentSet("any:single conflict",
-                        "The exclusive bind of port(s) 9080 to <any> would conflict with existing exclusive port bindings on <any>.",
+                        Set.of("Configuration for listener 'default' of virtual cluster 'two' conflicts with configuration for virtual cluster: 'one'.",
+                                "The exclusive bind of port(s) 9080 to <any> would conflict with existing exclusive port bindings on <any>."),
                         null,
                         List.of(createMockVirtualCluster("one", Set.of(9080), Set.of(), any),
                                 createMockVirtualCluster("two", Set.of(9080), Set.of(), any))),
                 argumentSet("any:many exclusive conflicts",
-                        "The exclusive bind of port(s) 9080,9081 to <any> would conflict with existing exclusive port bindings on <any>.",
+                        Set.of("Configuration for listener 'default' of virtual cluster 'two' conflicts with configuration for virtual cluster: 'one'.",
+                                "The exclusive bind of port(s) 9080,9081 to <any> would conflict with existing exclusive port bindings on <any>."),
                         null,
                         List.of(createMockVirtualCluster("one", Set.of(9080, 9081), Set.of(), any),
                                 createMockVirtualCluster("two", Set.of(9080, 9081), Set.of(), any))),
                 argumentSet("any:overlap produces exclusive conflict ",
-                        "The exclusive bind of port(s) 9081 to <any> would conflict with existing exclusive port bindings on <any>.",
+                        Set.of("Configuration for listener 'default' of virtual cluster 'two' conflicts with configuration for virtual cluster: 'one'.",
+                                "The exclusive bind of port(s) 9081 to <any> would conflict with existing exclusive port bindings on <any>."),
                         null,
                         List.of(createMockVirtualCluster("one", Set.of(9080, 9081), Set.of(), any),
                                 createMockVirtualCluster("two", Set.of(9081, 9082), Set.of(), any))),
                 argumentSet("loopback:single exclusive conflict",
-                        "The exclusive bind of port(s) 9080 to 127.0.0.1 would conflict with existing exclusive port bindings on 127.0.0.1.",
+                        Set.of("Configuration for listener 'default' of virtual cluster 'two' conflicts with configuration for virtual cluster: 'one'.",
+                                "The exclusive bind of port(s) 9080 to 127.0.0.1 would conflict with existing exclusive port bindings on 127.0.0.1."),
                         null,
                         List.of(createMockVirtualCluster("one", Set.of(9080), Set.of(), loopback),
                                 createMockVirtualCluster("two", Set.of(9080), Set.of(), loopback))),
                 argumentSet("loopback/any:single exclusive conflict",
-                        "The exclusive bind of port(s) 9080 to <any> would conflict with existing exclusive port bindings on 127.0.0.1.",
+                        Set.of("Configuration for listener 'default' of virtual cluster 'two' conflicts with configuration for virtual cluster: 'one'.",
+                                "The exclusive bind of port(s) 9080 to <any> would conflict with existing exclusive port bindings on 127.0.0.1."),
                         null,
                         List.of(createMockVirtualCluster("one", Set.of(9080), Set.of(), loopback),
                                 createMockVirtualCluster("two", Set.of(9080), Set.of(), any))),
                 argumentSet("any/loopback:single exclusive conflict",
-                        "The exclusive bind of port(s) 9080 to 127.0.0.1 would conflict with existing exclusive port bindings on <any>.",
+                        Set.of("Configuration for listener 'default' of virtual cluster 'two' conflicts with configuration for virtual cluster: 'one'.",
+                                "The exclusive bind of port(s) 9080 to 127.0.0.1 would conflict with existing exclusive port bindings on <any>."),
                         null,
                         List.of(createMockVirtualCluster("one", Set.of(9080), Set.of(), any),
                                 createMockVirtualCluster("two", Set.of(9080), Set.of(), loopback))),
                 argumentSet("any/loopback:single shared conflict",
-                        "The shared bind of port(s) 9080 to 127.0.0.1 would conflict with existing shared port bindings on <any>.",
+                        Set.of("Configuration for listener 'default' of virtual cluster 'two' conflicts with configuration for virtual cluster: 'one'.",
+                                "The shared bind of port(s) 9080 to 127.0.0.1 would conflict with existing shared port bindings on <any>."),
                         null,
                         List.of(createMockVirtualCluster("one", Set.of(), Set.of(9080), any),
                                 createMockVirtualCluster("two", Set.of(), Set.of(9080), loopback))),
                 argumentSet("loopback/any:single shared conflict",
-                        "The shared bind of port(s) 9080 to <any> would conflict with existing shared port bindings on 127.0.0.1.",
+                        Set.of("Configuration for listener 'default' of virtual cluster 'two' conflicts with configuration for virtual cluster: 'one'.",
+                                "The shared bind of port(s) 9080 to <any> would conflict with existing shared port bindings on 127.0.0.1."),
                         null,
                         List.of(createMockVirtualCluster("one", Set.of(), Set.of(9080), loopback),
                                 createMockVirtualCluster("two", Set.of(), Set.of(9080), any))),
                 argumentSet("shared/exclusivity mismatch",
-                        "The exclusive bind of port(s) 9080 to <any> would conflict with existing shared port bindings on <any>.",
+                        Set.of("Configuration for listener 'default' of virtual cluster 'two' conflicts with configuration for virtual cluster: 'one'.",
+                                "The exclusive bind of port(s) 9080 to <any> would conflict with existing shared port bindings on <any>."),
                         null,
                         List.of(createMockVirtualCluster("one", Set.of(), Set.of(9080), any),
                                 createMockVirtualCluster("two", Set.of(9080), Set.of(), any))),
                 argumentSet("exclusivity/shared mismatch",
-                        "The shared bind of port(s) 9080 to <any> would conflict with existing exclusive port bindings on <any>.",
+                        Set.of("Configuration for listener 'default' of virtual cluster 'two' conflicts with configuration for virtual cluster: 'one'.",
+                                "The shared bind of port(s) 9080 to <any> would conflict with existing exclusive port bindings on <any>."),
                         null,
                         List.of(createMockVirtualCluster("one", Set.of(9080), Set.of(), any),
-                                createMockVirtualCluster("one", Set.of(), Set.of(9080), any))),
+                                createMockVirtualCluster("two", Set.of(), Set.of(9080), any))),
                 argumentSet("shared tls mismatch",
-                        "The shared bind of port 9080 to <any> has conflicting TLS settings with existing port on the same interface.",
+                        Set.of("Configuration for listener 'default' of virtual cluster 'two' conflicts with configuration for virtual cluster: 'one'.",
+                                "The shared bind of port 9080 to <any> has conflicting TLS settings with existing port on the same interface."),
                         null,
                         List.of(createMockVirtualCluster("one", Set.of(), Set.of(9080), any, true),
                                 createMockVirtualCluster("two", Set.of(), Set.of(9080), any, false))),
                 argumentSet("shared tls mismatch",
-                        "The shared bind of port 9080 to 127.0.0.1 has conflicting TLS settings with existing port on the same interface.",
+                        Set.of("Configuration for listener 'default' of virtual cluster 'two' conflicts with configuration for virtual cluster: 'one'.",
+                                "The shared bind of port 9080 to 127.0.0.1 has conflicting TLS settings with existing port on the same interface."),
                         null,
                         List.of(createMockVirtualCluster("one", Set.of(), Set.of(9080), loopback, false),
                                 createMockVirtualCluster("two", Set.of(), Set.of(9080), loopback, true))),
                 argumentSet("different exclusive ports",
-                        null,
+                        Set.of(),
                         null,
                         List.of(createMockVirtualCluster("one", Set.of(9080), Set.of(), any),
                                 createMockVirtualCluster("two", Set.of(9081), Set.of(), any))),
                 argumentSet("same shared ports",
-                        null,
+                        Set.of(),
                         null,
                         List.of(createMockVirtualCluster("one", Set.of(), Set.of(9080), any),
                                 createMockVirtualCluster("two", Set.of(), Set.of(9080), any))),
                 argumentSet("same shared shared ports different interfaces with differing tls",
-                        null,
+                        Set.of(),
                         null,
                         List.of(createMockVirtualCluster("one", Set.of(), Set.of(9080), loopback, true),
                                 createMockVirtualCluster("two", Set.of(), Set.of(9080), privateUse, false))),
                 argumentSet("same exclusive port different interfaces",
-                        null,
+                        Set.of(),
                         null,
                         List.of(createMockVirtualCluster("one", Set.of(9080), Set.of(), privateUse),
                                 createMockVirtualCluster("two", Set.of(9080), Set.of(), loopback))),
                 argumentSet("different exclusive ports, collides with other exclusive port on any interface",
-                        "The exclusive bind of port(s) 9080 for virtual cluster 'one' to <any> would conflict with another (non-cluster) port binding",
+                        Set.of("The exclusive bind of port(s) 9080 for listener 'default' of virtual cluster 'one' to <any> would conflict with another (non-cluster) port binding"),
                         new HostPort("0.0.0.0", 9080),
                         List.of(createMockVirtualCluster("one", Set.of(9080), Set.of(), any),
                                 createMockVirtualCluster("two", Set.of(9081), Set.of(), any))),
                 argumentSet("different exclusive ports on any interface, collides with other exclusive port on specific interface",
-                        "The exclusive bind of port(s) 9080 for virtual cluster 'one' to <any> would conflict with another (non-cluster) port binding",
+                        Set.of("The exclusive bind of port(s) 9080 for listener 'default' of virtual cluster 'one' to <any> would conflict with another (non-cluster) port binding"),
                         new HostPort(loopback, 9080),
                         List.of(createMockVirtualCluster("one", Set.of(9080), Set.of(), any),
                                 createMockVirtualCluster("two", Set.of(9081), Set.of(), any))),
                 argumentSet("different exclusive ports on specific interface, collides with other exclusive port on any interface",
-                        "The exclusive bind of port(s) 9080 for virtual cluster 'one' to 127.0.0.1 would conflict with another (non-cluster) port binding",
+                        Set.of("The exclusive bind of port(s) 9080 for listener 'default' of virtual cluster 'one' to 127.0.0.1 would conflict with another (non-cluster) port binding"),
                         new HostPort("0.0.0.0", 9080),
                         List.of(createMockVirtualCluster("one", Set.of(9080), Set.of(), loopback),
                                 createMockVirtualCluster("two", Set.of(9081), Set.of(), loopback))),
                 argumentSet("same shared ports, collides with other exclusive port on any interface",
-                        "The shared bind of port(s) 9080 for virtual cluster 'one' to <any> would conflict with another (non-cluster) port binding",
+                        Set.of("The shared bind of port(s) 9080 for listener 'default' of virtual cluster 'one' to <any> would conflict with another (non-cluster) port binding"),
                         new HostPort("0.0.0.0", 9080),
                         List.of(createMockVirtualCluster("one", Set.of(), Set.of(9080), any),
                                 createMockVirtualCluster("two", Set.of(), Set.of(9080), any))),
                 argumentSet("same shared shared ports different interfaces with differing tls, collides with other exclusive port",
-                        "The shared bind of port(s) 9080 for virtual cluster 'one' to 127.0.0.1 would conflict with another (non-cluster) port binding",
+                        Set.of("The shared bind of port(s) 9080 for listener 'default' of virtual cluster 'one' to 127.0.0.1 would conflict with another (non-cluster) port binding"),
                         new HostPort(loopback, 9080),
                         List.of(createMockVirtualCluster("one", Set.of(), Set.of(9080), loopback, true),
                                 createMockVirtualCluster("two", Set.of(), Set.of(9080), privateUse, false))),
                 argumentSet("same exclusive port different interfaces, collides with other exclusive port",
-                        "The exclusive bind of port(s) 9080 for virtual cluster 'two' to 127.0.0.1 would conflict with another (non-cluster) port binding",
+                        Set.of("The exclusive bind of port(s) 9080 for listener 'default' of virtual cluster 'two' to 127.0.0.1 would conflict with another (non-cluster) port binding"),
                         new HostPort(loopback, 9080),
                         List.of(createMockVirtualCluster("one", Set.of(9080), Set.of(), privateUse),
                                 createMockVirtualCluster("two", Set.of(9080), Set.of(), loopback))),
                 argumentSet("any:single conflict within virtual cluster",
-                        "The exclusive bind of port(s) 9080 to <any> would conflict with existing exclusive port bindings on <any>.",
+                        Set.of("Configuration for listener 'listener1' of virtual cluster 'one' conflicts with configuration for virtual cluster: 'one'.",
+                                "The exclusive bind of port(s) 9080 to <any> would conflict with existing exclusive port bindings on <any>."),
                         null,
-                        List.of(createMockVirtualCluster("one", getVirtualClusterListenerModel(Set.of(9080), Set.of(), any, false),
-                                getVirtualClusterListenerModel(Set.of(9080), Set.of(), any, false)))));
+                        List.of(createMockVirtualCluster("one", getVirtualClusterListenerModel(Set.of(9080), Set.of(), any, false, "listener1"),
+                                getVirtualClusterListenerModel(Set.of(9080), Set.of(), any, false, "listener2")))));
     }
 
     @ParameterizedTest
     @MethodSource
-    void portConflict(String expectedMessageSuffix, HostPort otherExclusivePort, List<VirtualClusterModel> clusters) {
+    void portConflict(Set<String> expectedExceptionMessages, HostPort otherExclusivePort, List<VirtualClusterModel> clusters) {
         Optional<HostPort> maybeOtherExclusivePort = Optional.ofNullable(otherExclusivePort);
-        if (expectedMessageSuffix == null) {
+        if (expectedExceptionMessages.isEmpty()) {
             detector.validate(clusters, maybeOtherExclusivePort);
         }
         else {
             var e = assertThrows(IllegalStateException.class, () -> detector.validate(clusters, maybeOtherExclusivePort));
-            assertThat(e).hasStackTraceContaining(expectedMessageSuffix);
+            for (String expectedMessage : expectedExceptionMessages) {
+                assertThat(e).hasStackTraceContaining(expectedMessage);
+            }
         }
     }
 
@@ -178,24 +192,27 @@ class PortConflictDetectorTest {
 
     private static VirtualClusterModel createMockVirtualCluster(String clusterName, Set<Integer> exclusivePorts, Set<Integer> sharedPorts, String bindAddress,
                                                                 boolean tls) {
-        return createMockVirtualCluster(clusterName, getVirtualClusterListenerModel(exclusivePorts, sharedPorts, bindAddress, tls));
+        return createMockVirtualCluster(clusterName, getVirtualClusterListenerModel(exclusivePorts, sharedPorts, bindAddress, tls, "default"));
     }
 
     private static VirtualClusterModel createMockVirtualCluster(String clusterName, VirtualClusterListenerModel... listenerModel) {
         var virtualClusterModel = mock(VirtualClusterModel.class);
-        var listenerMap = Arrays.stream(listenerModel).collect(Collectors.toMap(l -> "listener-" + UUID.randomUUID(), l -> l));
+        var listenerMap = Arrays.stream(listenerModel).collect(Collectors.toMap(VirtualClusterListenerModel::name, l -> l));
         when(virtualClusterModel.listeners()).thenAnswer(invocation -> listenerMap);
         when(virtualClusterModel.getClusterName()).thenReturn(clusterName);
+        listenerMap.values().forEach(l -> when(l.virtualCluster()).thenReturn(virtualClusterModel));
         return virtualClusterModel;
     }
 
     @NonNull
-    private static VirtualClusterListenerModel getVirtualClusterListenerModel(Set<Integer> exclusivePorts, Set<Integer> sharedPorts, String bindAddress, boolean tls) {
+    private static VirtualClusterListenerModel getVirtualClusterListenerModel(Set<Integer> exclusivePorts, Set<Integer> sharedPorts, String bindAddress, boolean tls,
+                                                                              String listenerName) {
         var cluster = mock(VirtualClusterListenerModel.class);
         when(cluster.getExclusivePorts()).thenReturn(exclusivePorts);
         when(cluster.getSharedPorts()).thenReturn(sharedPorts);
         when(cluster.getBindAddress()).thenReturn(Optional.ofNullable(bindAddress));
         when(cluster.isUseTls()).thenReturn(tls);
+        when(cluster.name()).thenReturn(listenerName);
         return cluster;
     }
 

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/model/VirtualClusterListenerModelTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/model/VirtualClusterListenerModelTest.java
@@ -79,7 +79,7 @@ class VirtualClusterListenerModelTest {
     @Test
     void delegatesToProviderForAdvertisedPort() {
         var mock = mock(ClusterNetworkAddressConfigProvider.class);
-        var listener = new VirtualClusterListenerModel(mock(VirtualClusterModel.class), mock, Optional.empty());
+        var listener = new VirtualClusterListenerModel(mock(VirtualClusterModel.class), mock, Optional.empty(), "default");
         var advertisedHostPort = new HostPort("broker", 55);
         when(mock.getAdvertisedBrokerAddress(0)).thenReturn(advertisedHostPort);
         assertThat(listener.getAdvertisedBrokerAddress(0)).isEqualTo(advertisedHostPort);
@@ -94,7 +94,7 @@ class VirtualClusterListenerModelTest {
         var clusterNetworkAddressConfigProvider = createTestClusterNetworkAddressConfigProvider();
 
         // When
-        var listener = new VirtualClusterListenerModel(mock(VirtualClusterModel.class), clusterNetworkAddressConfigProvider, downstreamTls);
+        var listener = new VirtualClusterListenerModel(mock(VirtualClusterModel.class), clusterNetworkAddressConfigProvider, downstreamTls, "default");
 
         // Then
         assertThat(listener).isNotNull().extracting("downstreamSslContext").isNotNull();
@@ -133,7 +133,7 @@ class VirtualClusterListenerModelTest {
         var clusterNetworkAddressConfigProvider = createTestClusterNetworkAddressConfigProvider();
 
         // When
-        var listener = new VirtualClusterListenerModel(mock(VirtualClusterModel.class), clusterNetworkAddressConfigProvider, downstreamTls);
+        var listener = new VirtualClusterListenerModel(mock(VirtualClusterModel.class), clusterNetworkAddressConfigProvider, downstreamTls, "default");
 
         // Then
         assertThat(listener)
@@ -166,7 +166,7 @@ class VirtualClusterListenerModelTest {
         var clusterNetworkAddressConfigProvider = createTestClusterNetworkAddressConfigProvider();
 
         // When
-        var listener = new VirtualClusterListenerModel(mock(VirtualClusterModel.class), clusterNetworkAddressConfigProvider, tls);
+        var listener = new VirtualClusterListenerModel(mock(VirtualClusterModel.class), clusterNetworkAddressConfigProvider, tls, "default");
 
         // Then
         assertThat(listener)
@@ -199,7 +199,7 @@ class VirtualClusterListenerModelTest {
         var clusterNetworkAddressConfigProvider = createTestClusterNetworkAddressConfigProvider();
 
         // When
-        var listener = new VirtualClusterListenerModel(mock(VirtualClusterModel.class), clusterNetworkAddressConfigProvider, tls);
+        var listener = new VirtualClusterListenerModel(mock(VirtualClusterModel.class), clusterNetworkAddressConfigProvider, tls, "default");
 
         // Then
         assertThat(listener)


### PR DESCRIPTION
PortConflictDetector exceptions include listener name.

This adds `String EndpointListener#name()` so that we can get at the name from the detector

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
