### PR TITLE
KafkaClusterRefs updates

### DIFF
--- a/kroxylicious-operator/examples/record-encryption/03.KafkaClusterRef.my-cluster.yaml
+++ b/kroxylicious-operator/examples/record-encryption/03.KafkaClusterRef.my-cluster.yaml
@@ -5,14 +5,10 @@
 #
 
 ---
-kind: VirtualKafkaCluster
+kind: KafkaClusterRef
 apiVersion: kroxylicious.io/v1alpha1
 metadata:
   name: my-cluster
   namespace: my-proxy
 spec:
-  proxyRef:
-    name: simple
-  targetCluster:
-    bootstrapping:
-      bootstrapAddress: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
+  bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092

--- a/kroxylicious-operator/examples/record-encryption/04.VirtualKafkaCluster.my-cluster.yaml
+++ b/kroxylicious-operator/examples/record-encryption/04.VirtualKafkaCluster.my-cluster.yaml
@@ -1,0 +1,22 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: VirtualKafkaCluster
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: my-cluster
+  namespace: my-proxy
+spec:
+  proxyRef:
+    name: simple
+  targetCluster:
+    clusterRef:
+      name: my-cluster
+  filters:
+    - group: filter.kroxylicious.io
+      kind: KafkaProtocolFilter
+      name: encryption

--- a/kroxylicious-operator/examples/record-validation/03.KafkaClusterRef.my-cluster.yaml
+++ b/kroxylicious-operator/examples/record-validation/03.KafkaClusterRef.my-cluster.yaml
@@ -1,0 +1,14 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaClusterRef
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: my-cluster
+  namespace: my-proxy
+spec:
+  bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092

--- a/kroxylicious-operator/examples/record-validation/04.VirtualKafkaCluster.my-cluster.yaml
+++ b/kroxylicious-operator/examples/record-validation/04.VirtualKafkaCluster.my-cluster.yaml
@@ -14,10 +14,9 @@ spec:
   proxyRef:
     name: simple
   targetCluster:
-    bootstrapping:
-      bootstrapAddress:
-        my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
+    clusterRef:
+      name: my-cluster
   filters:
     - group: filter.kroxylicious.io
-      kind: KafkaProtocolFilter
-      name: encryption
+      kind: RecordValidation
+      name: validation

--- a/kroxylicious-operator/examples/simple/02.KafkaClusterRef.my-cluster.yaml
+++ b/kroxylicious-operator/examples/simple/02.KafkaClusterRef.my-cluster.yaml
@@ -1,0 +1,14 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaClusterRef
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: my-cluster
+  namespace: my-proxy
+spec:
+  bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092

--- a/kroxylicious-operator/examples/simple/03.VirtualKafkaCluster.my-cluster.yaml
+++ b/kroxylicious-operator/examples/simple/03.VirtualKafkaCluster.my-cluster.yaml
@@ -14,9 +14,5 @@ spec:
   proxyRef:
     name: simple
   targetCluster:
-    bootstrapping:
-      bootstrapAddress: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
-  filters:
-    - group: filter.kroxylicious.io
-      kind: RecordValidation
-      name: validation
+    clusterRef:
+      name: my-cluster

--- a/kroxylicious-operator/install/01.ClusterRole.kroxylicious-operator-watched.yaml
+++ b/kroxylicious-operator/install/01.ClusterRole.kroxylicious-operator-watched.yaml
@@ -19,6 +19,7 @@ rules:
     resources:
       - kafkaproxies
       - virtualkafkaclusters
+      - kafkaclusterrefs
     verbs:
       - get
       - list


### PR DESCRIPTION
Use clusterRef in `examples`.

Update RBAC so operator running on k8s can work with kafkaclusterrefs.

Adds another IT