### PR TITLE
Shuffle SocketAddress handling to Endpoint.createEndpoint

### DIFF
--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/Endpoint.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/Endpoint.java
@@ -6,6 +6,8 @@
 
 package io.kroxylicious.proxy.internal.net;
 
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -21,8 +23,22 @@ public record Endpoint(Optional<String> bindingAddress, int port, boolean tls) {
         Objects.requireNonNull(bindingAddress);
     }
 
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
     public static Endpoint createEndpoint(Optional<String> bindingAddress, int port, boolean tls) {
         return new Endpoint(bindingAddress, port, tls);
+    }
+
+    public static Endpoint createEndpoint(SocketAddress bindingSocketAddress, boolean tls) {
+        if (bindingSocketAddress instanceof InetSocketAddress inetSocketAddress) {
+            int targetPort = inetSocketAddress.getPort();
+            var bindingAddress = inetSocketAddress.getAddress().isAnyLocalAddress() ? Optional.<String> empty()
+                    : Optional.of(inetSocketAddress.getAddress().getHostAddress());
+            return new Endpoint(bindingAddress, targetPort, tls);
+        }
+        /* else if (bindingSocketAddress instanceof DomainSocketAddress) {
+            // TODO generalise end point to support domain sockets
+        }*/
+        throw new UnsupportedOperationException("Endpoints only support InetSocketAddress");
     }
 
     public static Endpoint createEndpoint(int port, boolean tls) {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
@@ -26,10 +26,12 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelPipeline;
+import io.netty.channel.DefaultChannelId;
 import io.netty.channel.EventLoop;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.channel.socket.ServerSocketChannel;
@@ -38,6 +40,7 @@ import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.handler.codec.MessageToByteEncoder;
 import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.ssl.SniHandler;
+import io.netty.util.internal.StringUtil;
 
 import io.kroxylicious.proxy.bootstrap.FilterChainFactory;
 import io.kroxylicious.proxy.config.ServiceBasedPluginFactoryRegistry;
@@ -50,6 +53,7 @@ import io.kroxylicious.proxy.internal.filter.ApiVersionsIntersectFilter;
 import io.kroxylicious.proxy.internal.net.Endpoint;
 import io.kroxylicious.proxy.internal.net.EndpointBinding;
 import io.kroxylicious.proxy.internal.net.EndpointBindingResolver;
+import io.kroxylicious.proxy.internal.net.EndpointResolutionException;
 import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.service.ClusterNetworkAddressConfigProvider;
 import io.kroxylicious.proxy.service.HostPort;
@@ -57,6 +61,7 @@ import io.kroxylicious.proxy.service.HostPort;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 import static io.kroxylicious.proxy.internal.KafkaProxyInitializer.LOGGING_INBOUND_ERROR_HANDLER_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -289,6 +294,38 @@ class KafkaProxyInitializerTest {
         // Then
         verify(channelPipeline).addLast(anyString(), isA(SniHandler.class));
         assertErrorHandlerAdded();
+    }
+
+    @Test
+    void shouldCloseConnectionOnUnrecognizedSniHostName() {
+        // Given
+        var endpointBindingResolver = mock(EndpointBindingResolver.class);
+        var embeddedChannel = new EmbeddedChannel(serverSocketChannel, DefaultChannelId.newInstance(), true, false);
+        kafkaProxyInitializer = createKafkaProxyInitializer(true, endpointBindingResolver, Map.of());
+        kafkaProxyInitializer.initChannel(embeddedChannel);
+        when(endpointBindingResolver.resolve(any(), eq("chat4.leancloud.cn"))).thenReturn(CompletableFuture.failedStage(new EndpointResolutionException("not resolved")));
+
+        // lifted from the Netty tests
+        // hex dump of a client hello packet, which contains hostname "CHAT4.LEANCLOUD.CN"
+        String tlsHandshakeMessageHex1 = "16030100";
+        // part 2
+        String tlsHandshakeMessageHex = "c6010000c20303bb0855d66532c05a0ef784f7c384feeafa68b3" +
+                "b655ac7288650d5eed4aa3fb52000038c02cc030009fcca9cca8ccaac02b" +
+                "c02f009ec024c028006bc023c0270067c00ac0140039c009c0130033009d" +
+                "009c003d003c0035002f00ff010000610000001700150000124348415434" +
+                "2e4c45414e434c4f55442e434e000b000403000102000a000a0008001d00" +
+                "170019001800230000000d0020001e060106020603050105020503040104" +
+                "0204030301030203030201020202030016000000170000";
+        assertThat(embeddedChannel.isOpen())
+                .isTrue();
+
+        // When
+        embeddedChannel.writeInbound(Unpooled.wrappedBuffer(StringUtil.decodeHexDump(tlsHandshakeMessageHex1)),
+                Unpooled.wrappedBuffer(StringUtil.decodeHexDump(tlsHandshakeMessageHex)));
+
+        // Then
+        assertThat(embeddedChannel.isOpen())
+                .isFalse();
     }
 
     @Test

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/net/EndpointTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/net/EndpointTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.net;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EndpointTest {
+
+    @Test
+    void shouldCreateEndpointFromInetSocketAddress() {
+        // Given
+        InetSocketAddress inetSocketAddress = new InetSocketAddress("localhost", 1234);
+
+        // When
+        Endpoint actual = Endpoint.createEndpoint(inetSocketAddress, false);
+
+        // Then
+        assertThat(actual)
+                .isNotNull()
+                .satisfies(
+                        endpoint -> {
+                            assertThat(endpoint.bindingAddress()).isPresent().hasValue("127.0.0.1");
+                            assertThat(endpoint.port()).isEqualTo(1234);
+                        }
+                );
+    }
+
+    @Test
+    void shouldCreateEndpointFromPortOnly() {
+        // Given
+        InetSocketAddress inetSocketAddress = new InetSocketAddress(1234);
+
+        // When
+        Endpoint actual = Endpoint.createEndpoint(inetSocketAddress, false);
+
+        // Then
+        assertThat(actual)
+                .isNotNull()
+                .satisfies(
+                        endpoint -> {
+                            assertThat(endpoint.bindingAddress()).isEmpty();
+                            assertThat(endpoint.port()).isEqualTo(1234);
+                        }
+                );
+    }
+
+    @Test
+    void shouldCreateEndpointForAnyLocalAddress() {
+        // Given
+        InetSocketAddress inetSocketAddress = new InetSocketAddress(InetAddress.getLoopbackAddress(), 1234);
+
+        // When
+        Endpoint actual = Endpoint.createEndpoint(inetSocketAddress, false);
+
+        // Then
+        assertThat(actual)
+                .isNotNull()
+                .satisfies(
+                        endpoint -> {
+                            assertThat(endpoint.bindingAddress()).isPresent().hasValue("127.0.0.1");
+                            assertThat(endpoint.port()).isEqualTo(1234);
+                        }
+                );
+    }
+}


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Shuffle inet socket address handling into the Endpoint.

### Additional Context

I think in the longer term we should be able to support DomainSockets and thus this is really the API we want with endpoints. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
