### PR TITLE
test: verify all ITs run in workflow

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -25,7 +25,42 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  discover_integration_test_chunks:
+    runs-on: ubuntu-latest
+    outputs:
+      test_chunks: ${{ steps.discover.outputs.test_chunks }}
+      modules: ${{ steps.discover.outputs.modules }}
+    steps:
+      - name: 'Check out repository'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+      - name: 'Discover ITs'
+        id: discover
+        run: |
+          TESTS_PER_CHUNK=15
+          TEST_CHUNKS=$(./scripts/discover-integration-tests.sh ${TESTS_PER_CHUNK})
+
+          # Extract unique modules from the chunks JSON
+          # Parse "module:TestClass" format and get unique module artifact IDs (basename)
+          DISCOVERED_MODULES=$(echo "$TEST_CHUNKS" | jq -r '.[]' \
+            | tr ',' '\n' \
+            | cut -d: -f1 \
+            | xargs -n 1 basename \
+            | sort -u \
+            | sed 's|^|:|' \
+            | tr '\n' ',' \
+            | sed 's/,$//')
+
+          # Always include BOM as it's required for dependency management
+          MODULES=":kroxylicious-bom,${DISCOVERED_MODULES}"
+
+          echo "test_chunks=$TEST_CHUNKS" >> $GITHUB_OUTPUT
+          echo "modules=$MODULES" >> $GITHUB_OUTPUT
+          echo "Discovered modules: $MODULES"
+          echo "Discovered $(echo "$TEST_CHUNKS" | jq -r 'length') test chunks"
   build_artifacts:
+    needs: discover_integration_test_chunks
     runs-on: ubuntu-latest
     steps:
       - name: 'Check out repository'
@@ -36,13 +71,14 @@ jobs:
         uses: ./.github/actions/common/setup-java
       - name: 'Cache Maven packages'
         uses: ./.github/actions/common/cache-maven-packages
-      - name: 'Build Kroxylicious proxy integration tests'
+      - name: 'Build Kroxylicious modules with integration tests'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          echo "Building modules: ${{ needs.discover_integration_test_chunks.outputs.modules }}"
           mvn --batch-mode \
             --activate-profiles '!qa' \
-            --projects :kroxylicious-bom,:kroxylicious-integration-tests,:kroxylicious-filter-archetype \
+            --projects ${{ needs.discover_integration_test_chunks.outputs.modules }} \
             --also-make \
             -DskipTests \
             -Dmaven.javadoc.skip=true \
@@ -60,22 +96,6 @@ jobs:
           name: kroxylicious-maven-artifacts
           path: /tmp/kroxylicious-artifacts/maven-repo.tar.gz
           retention-days: 1
-  discover_integration_test_chunks:
-    runs-on: ubuntu-latest
-    outputs:
-      test_chunks: ${{ steps.discover.outputs.test_chunks }}
-    steps:
-      - name: 'Check out repository'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          fetch-depth: 0
-      - name: 'Discover ITs'
-        working-directory: kroxylicious-integration-tests
-        id: discover
-        run: |
-          TESTS_PER_CHUNK=15
-          TEST_CHUNKS="[$(find . -type f -name "*IT.java" -exec basename {} .java \; | shuf | xargs -L ${TESTS_PER_CHUNK} | tr ' ' , | sed 's/.*/"&"/' | sed -z 's/\n/,/g;s/,$/\n/')]"
-          echo "test_chunks=$TEST_CHUNKS" >> $GITHUB_OUTPUT
   run_integration_tests:
     needs: [build_artifacts, discover_integration_test_chunks]
     runs-on: ubuntu-latest
@@ -84,8 +104,24 @@ jobs:
       matrix:
         tests: ${{ fromJson(needs.discover_integration_test_chunks.outputs.test_chunks) }}
     steps:
+      - name: Parse test specifications
+        id: parse
+        run: |
+          CHUNK="${{ matrix.tests }}"
+          echo "Processing chunk: $CHUNK"
+
+          # Extract module from first test (all tests in chunk are from same module)
+          FIRST_SPEC=$(echo "$CHUNK" | cut -d, -f1)
+          MODULE=$(echo "$FIRST_SPEC" | cut -d: -f1)
+
+          # Remove "module:" prefix from all tests
+          TEST_LIST=$(echo "$CHUNK" | sed "s|${MODULE}:||g")
+
+          echo "module=$MODULE" >> $GITHUB_OUTPUT
+          echo "tests=$TEST_LIST" >> $GITHUB_OUTPUT
+
       - name: Log tests to run
-        run: echo "Running tests on classes '${{ matrix.tests }}'"
+        run: echo "Running tests '${{ steps.parse.outputs.tests }}' in module '${{ steps.parse.outputs.module }}'"
       - name: 'Check out repository'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
@@ -104,7 +140,7 @@ jobs:
           mkdir -p "$HOME/.m2/repository"
           cd "$HOME/.m2/repository"
           tar xzf /tmp/kroxylicious-artifacts/maven-repo.tar.gz
-      - name: 'Run proxy Kroxylicious integration tests'
+      - name: 'Run integration tests'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # These variables/secrets support the Fortanix/KMS integration tests.   If the secrets are absent, the
@@ -112,13 +148,13 @@ jobs:
           KROXYLICIOUS_KMS_FORTANIX_API_ENDPOINT: ${{ vars.KROXYLICIOUS_KMS_FORTANIX_API_ENDPOINT }}
           KROXYLICIOUS_KMS_FORTANIX_ADMIN_API_KEY: ${{ secrets.KROXYLICIOUS_KMS_FORTANIX_ADMIN_API_KEY }}
           KROXYLICIOUS_KMS_FORTANIX_API_KEY: ${{ secrets.KROXYLICIOUS_KMS_FORTANIX_API_KEY }}
-        working-directory: kroxylicious-integration-tests
+        working-directory: ${{ steps.parse.outputs.module }}
         run: |
           mvn --batch-mode \
             --activate-profiles '!qa' \
             -DskipUTs \
             -Derrorprone.skip=true \
-            -Dit.test="${{ matrix.tests }}" \
+            -Dit.test="${{ steps.parse.outputs.tests }}" \
             verify
   integration_test_proxy:
     runs-on: ubuntu-latest
@@ -143,28 +179,3 @@ jobs:
         echo "$FAILED_JSON" | jq -r '"* [\(.name)](\(.url))"' >> $GITHUB_STEP_SUMMARY
         echo "$FAILED_JSON" | jq -r '"\(.name): \(.url)"'
         exit 1
-  integration_test_filter_archetype:
-    needs: build_artifacts
-    runs-on: ubuntu-latest
-    steps:
-      - name: 'Check out repository'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          fetch-depth: 0
-      - name: Setup Java
-        uses: ./.github/actions/common/setup-java
-      - name: 'Cache Maven packages'
-        uses: ./.github/actions/common/cache-maven-packages
-      - name: 'Download Kroxylicious Maven artifacts'
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          name: kroxylicious-maven-artifacts
-          path: /tmp/kroxylicious-artifacts
-      - name: 'Extract Kroxylicious Maven artifacts'
-        run: |
-          mkdir -p "$HOME/.m2/repository"
-          cd "$HOME/.m2/repository"
-          tar xzf /tmp/kroxylicious-artifacts/maven-repo.tar.gz
-      - name: 'run filter archetype integration tests'
-        working-directory: kroxylicious-filter-archetype
-        run: mvn -B verify

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -99,14 +99,12 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          KROXYLICIOUS_KMS_FORTANIX_API_ENDPOINT: ${{ vars.KROXYLICIOUS_KMS_FORTANIX_API_ENDPOINT }}
-          KROXYLICIOUS_KMS_FORTANIX_ADMIN_API_KEY: ${{ secrets.KROXYLICIOUS_KMS_FORTANIX_ADMIN_API_KEY }}
-          KROXYLICIOUS_KMS_FORTANIX_API_KEY: ${{ secrets.KROXYLICIOUS_KMS_FORTANIX_API_KEY }}
         run: |
           mvn --batch-mode \
             --activate-profiles 'ci,!qa' \
             --projects ''!:kroxylicious-operator'' \
             -Derrorprone.skip=true \
+            -DskipITs=true \
             -Djapicmp.skip=${REFERENCE_RELEASE_UNPUBLISHED} \
             verify \
             org.sonarsource.scanner.maven:sonar-maven-plugin:5.5.0.6356:sonar

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/KroxyliciousConfigUtils.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/KroxyliciousConfigUtils.java
@@ -28,7 +28,7 @@ public class KroxyliciousConfigUtils {
     public static final String DEFAULT_VIRTUAL_CLUSTER = "demo";
     public static final String DEFAULT_GATEWAY_NAME = "default";
 
-    static final HostPort DEFAULT_PROXY_BOOTSTRAP = new HostPort("localhost", 9192);
+    public static final HostPort DEFAULT_PROXY_BOOTSTRAP = new HostPort("localhost", 9192);
 
     /**
      * Create a KroxyliciousConfigBuilder with a single virtual cluster configured to

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/ProxyProtocolIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/ProxyProtocolIT.java
@@ -39,7 +39,6 @@ import io.kroxylicious.proxy.config.ConfigurationBuilder;
 import io.kroxylicious.proxy.config.ProxyProtocolConfig;
 import io.kroxylicious.proxy.config.ProxyProtocolMode;
 import io.kroxylicious.proxy.config.VirtualClusterBuilder;
-import io.kroxylicious.proxy.service.HostPort;
 import io.kroxylicious.proxy.tls.CertificateGenerator;
 import io.kroxylicious.test.Request;
 import io.kroxylicious.test.Response;
@@ -50,6 +49,7 @@ import io.kroxylicious.test.codec.KafkaRequestEncoder;
 import io.kroxylicious.test.codec.KafkaResponseDecoder;
 import io.kroxylicious.test.tester.KroxyliciousConfigUtils;
 
+import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.DEFAULT_PROXY_BOOTSTRAP;
 import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.defaultPortIdentifiesNodeGatewayBuilder;
 import static io.kroxylicious.test.tester.KroxyliciousTesters.mockKafkaKroxyliciousTester;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -401,7 +401,7 @@ class ProxyProtocolIT {
                         .withNewTargetCluster()
                         .withBootstrapServers(mockBootstrap)
                         .endTargetCluster()
-                        .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(new HostPort("localhost", 49592))
+                        .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(DEFAULT_PROXY_BOOTSTRAP)
                                 .withNewTls()
                                 .withNewKeyStoreKey()
                                 .withStoreFile(keystore.path().toString())

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/validation/JsonSchemaRecordValidationIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/validation/JsonSchemaRecordValidationIT.java
@@ -140,7 +140,7 @@ class JsonSchemaRecordValidationIT extends RecordValidationBaseIT {
     @BeforeAll
     static void init() {
         // An Apicurio Registry instance is required for this test to work, so we start one using a Generic Container
-        String image = "quay.io/apicurio/apicurio-registry:3.2.2@sha256:c051f74552f3f1d67bf4aee291774f438aefc8fb1dc916bfa9ffaaf24b70a011";
+        String image = "quay.io/apicurio/apicurio-registry:3.2.3@sha256:43f468182af66e083c2c97865109327503d74ece347e48987fb7165a27e77a62";
         DockerImageName dockerImageName = DockerImageName.parse(image)
                 .asCompatibleSubstituteFor(DockerImageName.parse(image.substring(0, image.indexOf("@"))));
 

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/validation/JsonSchemaRecordValidationTlsIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/validation/JsonSchemaRecordValidationTlsIT.java
@@ -107,7 +107,7 @@ class JsonSchemaRecordValidationTlsIT extends RecordValidationBaseIT {
         trustPem = keys.selfSignedCertificatePem().toString();
 
         // Start Apicurio Registry with TLS enabled
-        String image = "quay.io/apicurio/apicurio-registry:3.2.2@sha256:c051f74552f3f1d67bf4aee291774f438aefc8fb1dc916bfa9ffaaf24b70a011";
+        String image = "quay.io/apicurio/apicurio-registry:3.2.3@sha256:43f468182af66e083c2c97865109327503d74ece347e48987fb7165a27e77a62";
         DockerImageName dockerImageName = DockerImageName.parse(image)
                 .asCompatibleSubstituteFor(DockerImageName.parse(image.substring(0, image.indexOf("@"))));
 

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms-test-support/pom.xml
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms-test-support/pom.xml
@@ -125,10 +125,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.github.spotbugs</groupId>
-                <artifactId>spotbugs-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
             </plugin>

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms-test-support/src/main/java/io/kroxylicious/kms/provider/azure/kms/AzureKeyVaultKmsTestKmsFacade.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms-test-support/src/main/java/io/kroxylicious/kms/provider/azure/kms/AzureKeyVaultKmsTestKmsFacade.java
@@ -80,7 +80,7 @@ public class AzureKeyVaultKmsTestKmsFacade extends AbstractAzureKeyVaultKmsTestK
 
     @VisibleForTesting
     static LowkeyVaultContainer createLowKeyContainer() {
-        String image = "nagyesta/lowkey-vault:7.1.61-ubi10-minimal@sha256:f51b6781f0061a7c97dfeed54656e44dab5b572fe6304ec3a26ef652558b9007";
+        String image = "nagyesta/lowkey-vault:7.2.0-ubi10-minimal@sha256:79ad37ec96fc04b60c14a396f6b013b820b63c83614bac328e4ef9dacce5e59c";
         final DockerImageName imageName = DockerImageName.parse("mirror.gcr.io/" + image)
                 .asCompatibleSubstituteFor(DockerImageName.parse(image.substring(0, image.indexOf("@"))));
         final LowkeyVaultContainer lowkeyVaultContainer = lowkeyVault(imageName)

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/pom.xml
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/pom.xml
@@ -120,10 +120,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.github.spotbugs</groupId>
-                <artifactId>spotbugs-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/test/java/io/kroxylicious/kms/provider/azure/keyvault/KeyVaultClientIT.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/test/java/io/kroxylicious/kms/provider/azure/keyvault/KeyVaultClientIT.java
@@ -58,7 +58,7 @@ class KeyVaultClientIT {
     BearerTokenService bearerTokenService;
 
     LowkeyVaultContainer startVault() {
-        String image = "nagyesta/lowkey-vault:7.1.61-ubi10-minimal@sha256:f51b6781f0061a7c97dfeed54656e44dab5b572fe6304ec3a26ef652558b9007";
+        String image = "nagyesta/lowkey-vault:7.2.0-ubi10-minimal@sha256:79ad37ec96fc04b60c14a396f6b013b820b63c83614bac328e4ef9dacce5e59c";
         final DockerImageName imageName = DockerImageName.parse("mirror.gcr.io/" + image)
                 .asCompatibleSubstituteFor(DockerImageName.parse(image.substring(0, image.indexOf("@"))));
         final LowkeyVaultContainer lowkeyVaultContainer = lowkeyVault(imageName)

--- a/kroxylicious-openmessaging-benchmarks/Containerfile
+++ b/kroxylicious-openmessaging-benchmarks/Containerfile
@@ -13,7 +13,7 @@
 ARG OMB_COMMIT=85599891321cafa2fb7065a63f009b4bb5374288
 
 # ---------- Stage 1: build ----------
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.24-2.1776357031@sha256:253d78f68108c9188e810c6d534071dc16b437ddae185541c4292e2236c09d0a AS builder
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.24-2.1777030054@sha256:deccede6872a85ad264b6ca0a9794480bff8ec398eacf9b74e75208ad61ff306 AS builder
 USER root
 
 ARG OMB_COMMIT

--- a/kroxylicious-openmessaging-benchmarks/QUICKSTART.md
+++ b/kroxylicious-openmessaging-benchmarks/QUICKSTART.md
@@ -10,9 +10,12 @@ then run the benchmark suite.
   - Full benchmark run: 8 CPU cores, 16 GB RAM across the cluster (3 brokers + 3 OMB workers)
 - `kubectl` configured to access the cluster
 - `helm` 3.0+
-- `gh` (GitHub CLI) — for downloading the Kroxylicious operator release
-- `jbang` — for result comparison scripts ([install](https://www.jbang.dev/download/))
-- `mvn` — for generating JBang source filters
+- `gh` (GitHub CLI) — used by `setup-cluster.sh` to download the Kroxylicious operator release
+- `jbang` — used by the benchmark and result analysis scripts ([install](https://www.jbang.dev/download/))
+- `mvn` — run once before using any benchmark scripts to generate JBang source filters:
+  ```bash
+  mvn process-sources -pl kroxylicious-openmessaging-benchmarks
+  ```
 
 ### Start a local cluster (if needed)
 
@@ -68,13 +71,36 @@ To run one scenario and workload manually:
 ```bash
 ./scripts/run-benchmark.sh baseline 1topic-1kb ./results/baseline/
 ./scripts/run-benchmark.sh proxy-no-filters 1topic-1kb ./results/proxy/
+./scripts/run-benchmark.sh encryption 1topic-1kb ./results/encryption/
 
-# Compare afterwards
-./scripts/compare-results.sh ./results/baseline/*.json ./results/proxy/*.json
+# Compare afterwards (requires mvn process-sources to have been run once)
+./scripts/compare-results.sh ./results/baseline/result.json ./results/proxy/result.json
 ```
 
-Available scenarios: `baseline`, `proxy-no-filters`
+Available scenarios: `baseline`, `proxy-no-filters`, `encryption`
+
 Available workloads: `1topic-1kb`, `10topics-1kb`, `100topics-1kb`
+
+### Cluster-specific settings
+
+If your cluster requires non-default storage classes, image pull secrets, or resource limits,
+create a cluster overrides file and pass it with `--cluster-overrides`:
+
+```bash
+# cluster-overrides.yaml example
+kafka:
+  storage:
+    storageClass: my-storage-class
+```
+
+```bash
+./scripts/run-benchmark.sh \
+  --cluster-overrides ./cluster-overrides.yaml \
+  baseline 1topic-1kb ./results/baseline/
+```
+
+The `--cluster-overrides` file is applied last, so it always wins over scenario and profile
+defaults. Pass it to both `run-benchmark.sh` and `rate-sweep.sh`.
 
 ### Quick validation (smoke profile)
 
@@ -86,6 +112,33 @@ It fits comfortably within a 16 GB single-node cluster (minikube/kind).
 ./scripts/run-benchmark.sh \
   --profile ./helm/kroxylicious-benchmark/scenarios/smoke-values.yaml \
   baseline 1topic-1kb ./results/smoke/
+```
+
+### Finding the saturation point (rate sweep)
+
+To find the throughput ceiling for a scenario, use `rate-sweep.sh`. It deploys infrastructure
+once, then probes at increasing rates until the achieved throughput drops below the target,
+indicating saturation.
+
+```bash
+./scripts/rate-sweep.sh \
+  --scenarios baseline,encryption \
+  --min-rate 10000 \
+  --max-rate 60000 \
+  --step-percent 10 \
+  --output-dir ./results/sweep-$(date +%Y%m%d-%H%M%S)/
+```
+
+This prints a summary table at the end showing achieved rate and p99 latency at each probe,
+with saturation flagged where applicable. Use `--dry-run` to preview the rate sequence
+without deploying anything:
+
+```bash
+./scripts/rate-sweep.sh \
+  --scenarios encryption \
+  --min-rate 30000 --max-rate 50000 --step-percent 5 \
+  --output-dir /tmp/preview/ \
+  --dry-run
 ```
 
 ## Interpreting Results
@@ -144,4 +197,19 @@ kubectl get configmap omb-driver-baseline -n kafka \
   -o jsonpath='{.data.driver-kafka\.yaml}' | grep bootstrap
 # baseline:       bootstrap.servers=kafka-kafka-bootstrap:9092
 # proxy scenario: bootstrap.servers=kafka-cluster-ip-bootstrap:9292
+```
+
+**Scripts fail with "run mvn process-sources first"**
+
+The benchmark scripts use JBang to run Java-based result analysis tools. These tools are
+generated from annotated source files during the Maven build. If you see an error like:
+
+```
+Error: run 'mvn process-sources -pl kroxylicious-openmessaging-benchmarks' first to generate filtered sources
+```
+
+Run the following once from the repository root before using the scripts:
+
+```bash
+mvn process-sources -pl kroxylicious-openmessaging-benchmarks
 ```

--- a/kroxylicious-operator/pom.xml
+++ b/kroxylicious-operator/pom.xml
@@ -328,6 +328,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
+                    <skipTests>${skipITs}</skipTests>
                     <runOrder>random</runOrder>
                     <argLine>
                         <!-- https://junit-pioneer.org/docs/environment-variables/#warnings-for-reflective-access -->

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ResourcesUtil.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ResourcesUtil.java
@@ -610,10 +610,12 @@ public class ResourcesUtil {
                                                                           String eventSourceName) {
 
         Optional<Kafka> kafka = getKafka(context, eventSourceName);
-        return kafka.flatMap(value -> value.getStatus().getListeners().stream()
-                .filter(listenerStatus -> listenerStatus.getName()
-                        .equals(service.getSpec().getStrimziKafkaRef().getListenerName()))
-                .findFirst());
+        return kafka.flatMap(value -> Optional.ofNullable(value.getStatus())
+                .map(KafkaStatus::getListeners)
+                .flatMap(listeners -> listeners.stream()
+                        .filter(listenerStatus -> listenerStatus.getName()
+                                .equals(service.getSpec().getStrimziKafkaRef().getListenerName()))
+                        .findFirst()));
     }
 
     private static <T extends CustomResource<?, ?>> ResourceCheckResult<T> handleListener(T resource, StrimziKafkaRef strimziKafkaRef,

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceStrimziKafkaRefReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceStrimziKafkaRefReconcilerIT.java
@@ -266,12 +266,15 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
         AWAIT.untilAsserted(() -> {
             final KafkaService kafkaService = testActor.get(KafkaService.class, ResourcesUtil.name(cr));
             Assertions.assertThat(kafkaService).isNotNull();
-            Assertions.assertThat(kafkaService.getStatus().getBootstrapServers()).isEqualTo(expectedBootstrap);
             assertThat(kafkaService.getStatus())
                     .isNotNull()
-                    .conditionList()
-                    .singleElement()
-                    .isResolvedRefsTrue();
+                    .satisfies(status -> {
+                        Assertions.assertThat(status.getBootstrapServers()).isEqualTo(expectedBootstrap);
+                        assertThat(status)
+                                .conditionList()
+                                .singleElement()
+                                .isResolvedRefsTrue();
+                    });
             String checksum = getReferentChecksum(kafkaService);
             if (hasReferents) {
                 Assertions.assertThat(checksum).isNotEqualTo(NO_CHECKSUM_SPECIFIED);

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachine.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachine.java
@@ -17,6 +17,8 @@ import org.apache.kafka.common.message.ApiVersionsRequestData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.slf4j.Logger;
+import org.slf4j.event.Level;
+import org.slf4j.spi.LoggingEventBuilder;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Timer;
@@ -224,6 +226,8 @@ public class ProxyChannelStateMachine {
                     KafkaSession kafkaSession,
                     int transportAndBackendLatch) {
         LOGGER.atInfo()
+                .addKeyValue("sessionId", kafkaSession.sessionId())
+                .addKeyValue("virtualCluster", clusterName())
                 .addKeyValue("state", state)
                 .addKeyValue("frontendHandler", frontendHandler)
                 .addKeyValue("backendHandler", backendHandler)
@@ -332,10 +336,8 @@ public class ProxyChannelStateMachine {
     void onClientActive(KafkaProxyFrontendHandler frontendHandler) {
         if (STARTING_STATE.equals(this.state)) {
             this.frontendHandler = frontendHandler;
-            LOGGER.atDebug()
-                    .addKeyValue("sessionId", kafkaSession.sessionId())
-                    .addKeyValue("remoteHost", Objects.requireNonNull(this.frontendHandler).remoteHost())
-                    .addKeyValue("remotePort", this.frontendHandler.remotePort())
+            log(Level.DEBUG)
+                    .addKeyValue("address", () -> HostPort.asString(frontendHandler.remoteHost(), frontendHandler.remotePort()))
                     .log("Allocated session ID for downstream connection");
             ProxyChannelState.ClientActive clientActive = STARTING_STATE.toClientActive();
             toClientActive(clientActive, frontendHandler);
@@ -387,7 +389,7 @@ public class ProxyChannelStateMachine {
      */
     void illegalState(String msg) {
         if (!(state instanceof Closed)) {
-            LOGGER.atError()
+            log(Level.ERROR)
                     .addKeyValue("state", state)
                     .addKeyValue("message", msg)
                     .log("Unexpected event, closing channels with no client response");
@@ -496,7 +498,7 @@ public class ProxyChannelStateMachine {
      */
     @SuppressWarnings("java:S5738")
     void onServerException(@Nullable Throwable cause) {
-        LOGGER.atWarn()
+        log(Level.WARN)
                 .addKeyValue("error", cause != null ? cause.getMessage() : "")
                 .setCause(LOGGER.isDebugEnabled() ? cause : null)
                 .log(LOGGER.isDebugEnabled()
@@ -522,7 +524,7 @@ public class ProxyChannelStateMachine {
                     : " Possible unexpected TLS handshake? When connecting via TLS from your client, make sure to enable TLS for the Kroxylicious gateway ("
                             + StableKroxyliciousLinkGenerator.INSTANCE.errorLink(StableKroxyliciousLinkGenerator.CLIENT_TLS)
                             + ").";
-            LOGGER.atWarn()
+            log(Level.WARN)
                     .addKeyValue("maxFrameSizeBytes", e.getMaxFrameSizeBytes())
                     .addKeyValue("receivedFrameSizeBytes", e.getReceivedFrameSizeBytes())
                     .addKeyValue("hint", tlsHint)
@@ -530,7 +532,7 @@ public class ProxyChannelStateMachine {
             errorCodeEx = Errors.INVALID_REQUEST.exception();
         }
         else {
-            LOGGER.atWarn()
+            log(Level.WARN)
                     .addKeyValue("error", cause != null ? cause.getMessage() : "")
                     .setCause(LOGGER.isDebugEnabled() ? cause : null)
                     .log(LOGGER.isDebugEnabled()
@@ -632,11 +634,10 @@ public class ProxyChannelStateMachine {
         backendHandler = new KafkaProxyBackendHandler(this);
         Objects.requireNonNull(frontendHandler).inConnecting(connecting.remote(), backendHandler);
         proxyToServerConnectionCounter.increment();
-        LOGGER.atDebug()
-                .addKeyValue("sessionId", kafkaSession.sessionId())
+        var frontend = Objects.requireNonNull(this.frontendHandler);
+        log(Level.DEBUG)
                 .addKeyValue("remote", connecting.remote())
-                .addKeyValue("clientHost", Objects.requireNonNull(this.frontendHandler).remoteHost())
-                .addKeyValue("clientPort", this.frontendHandler.remotePort())
+                .addKeyValue("clientAddress", () -> HostPort.asString(frontend.remoteHost(), frontend.remotePort()))
                 .log("Upstream connection established for client");
     }
 
@@ -743,11 +744,24 @@ public class ProxyChannelStateMachine {
     }
 
     private void setState(ProxyChannelState state) {
-        LOGGER.atTrace()
+        log(Level.TRACE)
                 .addKeyValue("stateMachine", this)
                 .addKeyValue("targetState", state)
                 .log("Transitioning to state");
         this.state = state;
+    }
+
+    private LoggingEventBuilder log(Level level) {
+        LoggingEventBuilder builder = switch (level) {
+            case ERROR -> LOGGER.atError();
+            case WARN -> LOGGER.atWarn();
+            case INFO -> LOGGER.atInfo();
+            case DEBUG -> LOGGER.atDebug();
+            case TRACE -> LOGGER.atTrace();
+        };
+        return builder
+                .addKeyValue("sessionId", kafkaSession.sessionId())
+                .addKeyValue("virtualCluster", clusterName());
     }
 
     private static boolean isMessageApiVersionsRequest(Object msg) {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachineTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachineTest.java
@@ -112,6 +112,8 @@ class ProxyChannelStateMachineTest {
         when(endpointGateway.virtualCluster()).thenReturn(VIRTUAL_CLUSTER_MODEL);
         proxyChannelStateMachine = new ProxyChannelStateMachine(endpointBinding, new DefaultSubjectBuilder(List.of()), new KafkaSession(KafkaSessionState.ESTABLISHING));
         when(frontendHandler.channelId()).thenReturn(DefaultChannelId.newInstance());
+        when(frontendHandler.remoteHost()).thenReturn("testhost.example.com");
+        when(frontendHandler.remotePort()).thenReturn(9476);
         // Make the executor run tasks synchronously for tests
         when(frontendHandler.eventLoopExecutor()).thenReturn(Runnable::run);
     }

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/kms/azure/LowkeyVault.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/kms/azure/LowkeyVault.java
@@ -36,7 +36,7 @@ import static io.kroxylicious.systemtests.k8s.KubeClusterResource.kubeClient;
 public class LowkeyVault implements AzureKmsClient {
     private static final Logger LOGGER = LoggerFactory.getLogger(LowkeyVault.class);
     private static final String LOWKEY_VAULT_DEFAULT_NAMESPACE = "lowkey-vault";
-    private static final String IMAGE_NAME = "nagyesta/lowkey-vault:7.1.61-ubi10-minimal@sha256:f51b6781f0061a7c97dfeed54656e44dab5b572fe6304ec3a26ef652558b9007";
+    private static final String IMAGE_NAME = "nagyesta/lowkey-vault:7.2.0-ubi10-minimal@sha256:79ad37ec96fc04b60c14a396f6b013b820b63c83614bac328e4ef9dacce5e59c";
     @VisibleForTesting
     static final String LOWKEY_VAULT_IMAGE = Constants.DOCKER_REGISTRY_GCR_MIRROR + "/" + IMAGE_NAME;
     private final String deploymentNamespace;

--- a/scripts/discover-integration-tests.sh
+++ b/scripts/discover-integration-tests.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+set -euo pipefail
+
+# Set up SED for platform compatibility (gsed on macOS, sed on Linux)
+OS=$(uname)
+if [ "$OS" = 'Darwin' ]; then
+  SED=$(command -v gsed || echo "sed")
+else
+  SED=$(command -v sed)
+fi
+
+# Default chunk size
+TESTS_PER_CHUNK=${1:-15}
+
+# Discover ITs from all modules, format as "module:TestClass"
+# Exclude target dirs and archetype template resources
+TEST_LIST=$(find . -type f -name "*IT.java" \
+  -not -path "*/target/*" \
+  -not -path "*/archetype-resources/*" \
+  | while read -r file; do
+      testname=$(basename "$file" .java)
+      # Extract module path: ./kroxylicious-operator/src/... -> kroxylicious-operator
+      module=$(echo "$file" | ${SED} 's|^\./||' | ${SED} 's|/src/.*||')
+      echo "${module}:${testname}"
+    done | sort)
+
+# Group tests by module, shuffle within each module, then chunk
+# Compatible with bash 3.2+ (no associative arrays)
+CHUNKS=()
+current_module=""
+module_tests=""
+
+while IFS= read -r spec; do
+    if [ -z "$spec" ]; then
+        continue
+    fi
+
+    module=$(echo "$spec" | cut -d: -f1)
+    test=$(echo "$spec" | cut -d: -f2)
+
+    # If we hit a new module, process the previous module's tests
+    if [ -n "$current_module" ] && [ "$module" != "$current_module" ]; then
+        # Shuffle and chunk the accumulated tests
+        shuffled=$(echo "$module_tests" | tr ' ' '\n' | grep -v '^$' | shuf)
+        while IFS= read -r chunk; do
+            if [ -n "$chunk" ]; then
+                # Prefix each test with module: and convert spaces to commas
+                prefixed=$(echo "$chunk" | ${SED} "s|\([^ ]*\)|${current_module}:\1|g" | tr ' ' ',')
+                CHUNKS+=("\"$prefixed\"")
+            fi
+        done <<< "$(echo "$shuffled" | xargs -L ${TESTS_PER_CHUNK})"
+
+        # Reset for new module
+        module_tests=""
+    fi
+
+    current_module="$module"
+    module_tests="${module_tests}${test} "
+done <<< "$TEST_LIST"
+
+# Process the last module
+if [ -n "$current_module" ] && [ -n "$module_tests" ]; then
+    shuffled=$(echo "$module_tests" | tr ' ' '\n' | grep -v '^$' | shuf)
+    while IFS= read -r chunk; do
+        if [ -n "$chunk" ]; then
+            # Prefix each test with module: and convert spaces to commas
+            prefixed=$(echo "$chunk" | ${SED} "s|\([^ ]*\)|${current_module}:\1|g" | tr ' ' ',')
+            CHUNKS+=("\"$prefixed\"")
+        fi
+    done <<< "$(echo "$shuffled" | xargs -L ${TESTS_PER_CHUNK})"
+fi
+
+# Output JSON array
+TEST_CHUNKS="[$(IFS=,; echo "${CHUNKS[*]}")]"
+echo "$TEST_CHUNKS"

--- a/scripts/stage-release.sh
+++ b/scripts/stage-release.sh
@@ -89,8 +89,13 @@ ORIGINAL_WORKING_BRANCH=$(git branch --show-current)
 replaceInFile() {
   local EXPRESSION=$1
   local FILE=$2
-  ${SED} -i -e "${EXPRESSION}" "${FILE}"
+  ${SED} -E -i -e "${EXPRESSION}" "${FILE}"
   git add "${FILE}"
+}
+
+updateVersionInBenchmarks() {
+  replaceInFile "s|KROXYLICIOUS_VERSION:-[0-9]+\.[0-9]+\.[0-9]+|KROXYLICIOUS_VERSION:-${1}|g" \
+    kroxylicious-openmessaging-benchmarks/scripts/setup-cluster.sh
 }
 
 cleanup() {
@@ -147,6 +152,8 @@ replaceInFile "s_:KroxyliciousGitRef:.*_:KroxyliciousGitRef: v${RELEASE_VERSION}
 
 replaceInFile "s_image: 'quay.io/kroxylicious/proxy:.*'_image: 'quay.io/kroxylicious/proxy:${RELEASE_VERSION}'_g" compose/kafka-compose.yaml
 
+updateVersionInBenchmarks "${RELEASE_VERSION}"
+
 echo "Validating things still build"
 mvn -q -B clean install -Pquick
 
@@ -190,6 +197,8 @@ replaceInFile "s_:KroxyliciousVersion:.*_:KroxyliciousVersion: ${NEXT_VERSION}_g
 replaceInFile "s_:KroxyliciousGitRef:.*_:KroxyliciousGitRef: main_g" kroxylicious-docs/docs/_assets/attributes.adoc # this doesn't make a lot sense...
 
 replaceInFile "s_image: 'quay.io/kroxylicious/proxy:.*'_image: 'quay.io/kroxylicious/proxy:${NEXT_VERSION}'_g" compose/kafka-compose.yaml
+
+updateVersionInBenchmarks "${NEXT_VERSION}"
 
 # bump the reference version in kroxylicious-api
 mvn -q -B -pl :kroxylicious-api versions:set-property -Dproperty="ApiCompatability.ReferenceVersion" -DnewVersion="${RELEASE_VERSION}" -DgenerateBackupPoms=false


### PR DESCRIPTION
Testing the integration test workflow changes to verify all 108+ ITs are discovered and executed.

This PR tests the fixes for #3798 on my fork before submitting upstream.

Expected results:
- All modules with ITs should be built
- 108+ integration tests should be discovered across all modules
- Tests should run in their original module directories
- Module-specific configurations should be applied (operator JVM args, etc.)