### PR TITLE
Test: Add Minikube to integration-tests.yaml

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -56,7 +56,8 @@ jobs:
 
           # Always include BOM as it's required for dependency management
           # Also include filter-archetype as it has special IT requirements
-          MODULES=":kroxylicious-bom,:kroxylicious-filter-archetype,${DISCOVERED_MODULES}"
+          # Also include kroxylicious-app to build operand container image for operator ITs
+          MODULES=":kroxylicious-bom,:kroxylicious-filter-archetype,:kroxylicious-app,${DISCOVERED_MODULES}"
 
           echo "test_chunks=$TEST_CHUNKS" >> $GITHUB_OUTPUT
           echo "modules=$MODULES" >> $GITHUB_OUTPUT
@@ -65,6 +66,8 @@ jobs:
   build_artifacts:
     needs: discover_integration_test_chunks
     runs-on: ubuntu-latest
+    outputs:
+      kroxylicious_image: ${{ steps.build_image.outputs.KROXYLICIOUS_IMAGE }}
     steps:
       - name: 'Check out repository'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -74,20 +77,36 @@ jobs:
         uses: ./.github/actions/common/setup-java
       - name: 'Cache Maven packages'
         uses: ./.github/actions/common/cache-maven-packages
-      - name: 'Build Kroxylicious modules with integration tests'
+      - name: 'Build Kroxylicious modules with integration tests and operand image'
+        id: build_image
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          GIT_HASH="$(git rev-parse HEAD)"
+          KROXYLICIOUS_VERSION="$(mvn org.apache.maven.plugins:maven-help-plugin:3.4.0:evaluate -Dexpression=project.version -q -DforceStdout)"
+          KROXYLICIOUS_IMAGE="quay.io/kroxylicious/proxy:${KROXYLICIOUS_VERSION}-${GIT_HASH}"
+
           echo "Building modules: ${{ needs.discover_integration_test_chunks.outputs.modules }}"
+          echo "Building operand image: ${KROXYLICIOUS_IMAGE}"
+
           mvn --batch-mode \
-            --activate-profiles '!qa' \
+            --activate-profiles 'dist,!qa' \
             --projects ${{ needs.discover_integration_test_chunks.outputs.modules }} \
             --also-make \
             -DskipTests \
             -Dmaven.javadoc.skip=true \
             -DskipDocs=true \
             -Derrorprone.skip=true \
+            -Dio.kroxylicious.proxy.image.name="${KROXYLICIOUS_IMAGE}" \
             install
+
+          echo "KROXYLICIOUS_IMAGE=${KROXYLICIOUS_IMAGE}" >> "$GITHUB_OUTPUT"
+      - name: 'Upload Operand Image Artifact'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: kroxylicious-operand-image
+          path: kroxylicious-app/target/kroxylicious-proxy.img.tar.gz
+          retention-days: 1
       - name: 'Package Kroxylicious Maven artifacts'
         run: |
           mkdir -p /tmp/kroxylicious-artifacts
@@ -143,6 +162,45 @@ jobs:
           mkdir -p "$HOME/.m2/repository"
           cd "$HOME/.m2/repository"
           tar xzf /tmp/kroxylicious-artifacts/maven-repo.tar.gz
+      - name: Check if operator tests in chunk
+        id: check_operator
+        env:
+          CHUNK: ${{ matrix.tests }}
+        run: |
+          if echo "$CHUNK" | grep -q "kroxylicious-kubernetes/kroxylicious-operator:"; then
+            echo "has_operator_tests=true" >> "$GITHUB_OUTPUT"
+            echo "This chunk contains operator tests - Minikube will be started"
+          else
+            echo "has_operator_tests=false" >> "$GITHUB_OUTPUT"
+            echo "This chunk has no operator tests - Minikube will be skipped"
+          fi
+      - name: Set up Docker Buildx
+        if: steps.check_operator.outputs.has_operator_tests == 'true'
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+      - name: Setup Minikube
+        if: steps.check_operator.outputs.has_operator_tests == 'true'
+        uses: ./.github/actions/common/setup-minikube
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+      - name: Download Operand Image Artifact
+        if: steps.check_operator.outputs.has_operator_tests == 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: kroxylicious-operand-image
+          path: /tmp/kroxylicious-operand
+      - name: Load Operand Image in Minikube
+        if: steps.check_operator.outputs.has_operator_tests == 'true'
+        env:
+          KROXYLICIOUS_IMAGE: ${{ needs.build_artifacts.outputs.kroxylicious_image }}
+        run: |
+          # Load image into Minikube
+          minikube image load /tmp/kroxylicious-operand/kroxylicious-proxy.img.tar.gz
+
+          # Verify load succeeded (minikube image load exits 0 even on failure - see operator-maven.yaml:69-71)
+          minikube image ls | grep --fixed-strings "${KROXYLICIOUS_IMAGE}"
+
+          # Set environment variable for tests
+          echo "KROXYLICIOUS_IMAGE=${KROXYLICIOUS_IMAGE}" >> "${GITHUB_ENV}"
       - name: 'Run integration tests'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/operator-maven.yaml
+++ b/.github/workflows/operator-maven.yaml
@@ -45,30 +45,10 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
       - name: Setup Java
         uses: ./.github/actions/common/setup-java
-      - name: Setup Minikube
-        uses: ./.github/actions/common/setup-minikube
-        with:
-          githubToken: ${{ secrets.GITHUB_TOKEN }}
-      - name: 'Set up Docker Buildx'
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
       - name: 'Cache Maven packages'
         uses: ./.github/actions/common/cache-maven-packages
-      - name: 'Build Kroxylicious Operand Container Image'
-        run: |
-          GIT_HASH="$(git rev-parse HEAD)"
-          KROXYLICIOUS_VERSION="$(mvn org.apache.maven.plugins:maven-help-plugin:3.4.0:evaluate -Dexpression=project.version -q -DforceStdout)"
-          KROXYLICIOUS_IMAGE=quay.io/kroxylicious/proxy:${KROXYLICIOUS_VERSION}-${GIT_HASH}
-          mvn --batch-mode --activate-profiles dist --also-make --projects :kroxylicious-app -DskipTests clean package -Dio.kroxylicious.proxy.image.name=${KROXYLICIOUS_IMAGE}
-          echo "KROXYLICIOUS_IMAGE=${KROXYLICIOUS_IMAGE}" >> "${GITHUB_ENV}"
-      - name: 'Load Kroxylicious Operand Docker Image in Minikube'
-        run: |
-          # https://github.com/kubernetes/minikube/issues/21393 - minikube image load doesn't fail if the load fails.
-          minikube image load kroxylicious-app/target/kroxylicious-proxy.img.tar.gz
-          minikube image ls | grep --fixed-strings ${KROXYLICIOUS_IMAGE}
       - name: Cache SonarCloud packages
         uses: actions/cache@v5
         if: github.ref_name == 'main' && env.SONAR_TOKEN_SET == 'true'
@@ -86,6 +66,7 @@ jobs:
             --also-make \
             -Derrorprone.skip=true \
             -Djapicmp.skip=true \
+            -DskipITs=true \
             install
       - name: 'SonarCloud scan on main for the Operator'
         if: github.event_name == 'push' && github.ref_name == 'main' && env.SONAR_TOKEN_SET == 'true'
@@ -98,6 +79,7 @@ jobs:
             --projects ':kroxylicious-operator,:kroxylicious-kubernetes-parent,:kroxylicious-parent' \
             -Derrorprone.skip=true \
             -Djapicmp.skip=true \
+            -DskipITs=true \
             -Dsonar.projectName='Kroxylicious Operator' \
             -Dsonar.projectKey='kroxylicious_operator' \
             verify \


### PR DESCRIPTION
## Test PR for Workflow Changes

Testing the workflow changes to add Minikube support to integration-tests.yaml.

### Changes
- ✅ Add operand image building to build_artifacts job
- ✅ Add conditional Minikube setup (only for operator test chunks)
- ✅ Add -DskipITs to operator-maven.yaml to avoid duplication
- ✅ Simplify operator-maven.yaml (removed Minikube/Docker setup)

### Expected Results

**integration-tests.yaml:**
- Should discover all ITs including operator ITs
- Jobs with operator tests should start Minikube (~1-2 jobs out of 14)
- Jobs without operator tests should skip Minikube setup
- All 91 operator tests should RUN (not skip)
- Total: ~189 tests (98 non-operator + 91 operator)

**operator-maven.yaml:**
- Should build operator successfully
- Should skip all ITs (91 tests skipped)
- Faster execution (no Minikube overhead)

### Verification Commands

```bash
# Check operator ITs ran in integration-tests
RUN_ID=$(gh run list --repo k-wall/kroxylicious --workflow=integration-tests.yaml --limit=1 --json databaseId --jq '.[0].databaseId')
gh run view --repo k-wall/kroxylicious $RUN_ID --log | grep "kroxylicious-kubernetes/kroxylicious-operator" | grep "Tests run:"

# Check operator ITs skipped in operator-maven
RUN_ID=$(gh run list --repo k-wall/kroxylicious --workflow=operator-maven.yaml --limit=1 --json databaseId --jq '.[0].databaseId')
gh run view --repo k-wall/kroxylicious $RUN_ID --log | grep -i "skipITs"
```